### PR TITLE
Leverage catch2 feature: TEMPLATE_TEST_CASE

### DIFF
--- a/Tests/Tensor/test_tensor.cpp
+++ b/Tests/Tensor/test_tensor.cpp
@@ -1,5 +1,5 @@
 #include <complex>
-#include "catch2/catch.hpp"
+#include "../test.hpp"
 #include "Tensor/tensor.hpp"
 #include <typeinfo>
 
@@ -186,44 +186,29 @@ TEST_CASE( "TENSOR: 3D Constructor", "[Tensor,Constructor,3D]" ) {
 // Random Access
 // =============================================================================
 
-TEST_CASE( "TENSOR: 1D Random access", "[Tensor,Random Access, 1D"){
+TORCH_TYPE_TEST_CASE( "TENSOR: 1D Random access", "[Tensor,Random Access, 1D"){
    const size_type size = GENERATE(1, 100, 200);
 
-    test_random_access_1D<int>(size);
-    // floating point types
-    test_random_access_1D<float>(size);
-    test_random_access_1D<double>(size);
-    test_random_access_1D<NSL::complex<float>>(size);
-    test_random_access_1D<NSL::complex<double>>(size);
-    // bool types
-    test_random_access_1D<bool>(size);
+    test_random_access_1D<TestType>(size);
 }
 
-TEST_CASE( "TENSOR: 2D Random access", "[Tensor,Random Access, 2D"){
+TEMPLATE_TEST_CASE( "TENSOR: 2D Random access", "[Tensor,Random Access, 2D",
+    TORCH_TYPES)
+{
     const size_type size0 = GENERATE(1, 100, 200);
     const size_type size1 = GENERATE(1, 100, 200);
 
-    test_random_access_2D<int>(size0,size1);
-    // floating point types
-    test_random_access_2D<float>(size0,size1);
-    test_random_access_2D<double>(size0,size1);
-    test_random_access_2D<NSL::complex<float>>(size0,size1);
-    test_random_access_2D<NSL::complex<double>>(size0,size1);
-    // bool types
-    test_random_access_2D<bool>(size0,size1);
+    test_random_access_2D<TestType>(size0,size1);
 }
 
-TEST_CASE( "TENSOR: 3D Random access", "[Tensor,Random Access, 3D"){
+TEMPLATE_TEST_CASE( "TENSOR: 3D Random access", "[Tensor,Random Access, 3D", 
+    int,
+    FLOATING_POINT_TYPES,
+    bool)
+{
     const size_type size0 = GENERATE(1, 10, 20);
     const size_type size1 = GENERATE(1, 10, 20);
     const size_type size2 = GENERATE(1, 10, 20);
 
-    test_random_access_3D<int>(size0,size1,size2);
-    // floating point types
-    test_random_access_3D<float>(size0,size1,size2);
-    test_random_access_3D<double>(size0,size1,size2);
-    test_random_access_3D<NSL::complex<float>>(size0,size1,size2);
-    test_random_access_3D<NSL::complex<double>>(size0,size1,size2);
-    // bool types
-    test_random_access_3D<bool>(size0,size1,size2);
+    test_random_access_3D<TestType>(size0,size1,size2);
 }

--- a/Tests/test.hpp
+++ b/Tests/test.hpp
@@ -1,0 +1,24 @@
+#ifndef NSL_TEST_HPP
+#define NSL_TEST_HPP
+
+#include "catch2/catch.hpp"
+
+
+// ====================================================================
+// Type macros
+// ====================================================================
+
+#define REAL_TYPES float, double
+#define COMPLEX_TYPES NSL::complex<float>, NSL::complex<double>
+#define FLOATING_POINT_TYPES REAL_TYPES, COMPLEX_TYPES
+
+#define TORCH_TYPES int, FLOATING_POINT_TYPES, bool
+
+// ====================================================================
+// Custom TEST_CASE macros
+// ====================================================================
+
+#define TORCH_TYPE_TEST_CASE(_1, _2) TEMPLATE_TEST_CASE(_1, _2, TORCH_TYPES)
+
+
+#endif


### PR DESCRIPTION
According to [the catch2 documenation][catch2-docs],
`TEMPLATE_TEST_CASE` is the same as `TEST_CASE` except the
all the arguments after the second are types which are
looped over, giving different test cases.

In "Tests/test.hpp" I include catch2 and then provide macros which
expand to sequences of types: `REAL_TYPES`, `COMPLEX_TYPES` and
`FLOATING_POINT_TYPES` for floats, and `TORCH_TYPES` to include `int` and
`bool`.

Finally, I implemente a `TORCH_TYPE_TEST_CASE` macro which expands to a
catch2-native `TEMPLATE_TEST_CASE` with the appropriate types inserted.

In test_tensor.cpp I replaced three very verbose examples which had
explicit instantiation for each type with different, equivalent test
cases.  Two,
 - `"TENSOR: 2D Random access"`
 - `"TENSOR: 3D Random access"`
showing how to use the catch2 `TEMPLATE_TEST_CASE` explicitly and one
 - `"TENSOR: 1D Random access"`
which uses the custom macro.

The tests compile and pass.

[catch2-docs]: https://github.com/catchorg/Catch2/blob/devel/docs/test-cases-and-sections.md#type-parametrised-test-cases