### PR TITLE
Complex number fix

### DIFF
--- a/Tests/Lattice/test_ring.cpp
+++ b/Tests/Lattice/test_ring.cpp
@@ -27,8 +27,12 @@ void test_ring(const size_type & size, T kappa = 1.){
     REQUIRE(ring.sites() == size);
     REQUIRE(ring.bipartite() == (size%2 == 0));
 
-    INFO(ring.coordinates());
-    //! \todo Sum up the coordinates; they should evenly surround the origin.
+    NSL::Tensor<double> x = ring.coordinates();
+    NSL::Tensor<double> COM = x.sum(0);
+    double zero = 1e-12;
+    for(int i=0; i < COM.shape(0); i++){
+        REQUIRE( abs(COM(i)) <= zero );
+    }
 
     //  Perhaps make these their own stand-alone tests.
     //! \todo Require that adjacency^size has a diagonal of 2.
@@ -39,19 +43,11 @@ void test_ring(const size_type & size, T kappa = 1.){
 // Test Cases
 // =============================================================================
 
-// short int                Not Supported by torch
-//unsigned short int        Not Supported by torch
-//unsigned int              Not Supported by torch
-//size_type                  Not Supported by torch
-//unsigned size_type         Not Supported by torch
-//long size_type             Not Supported by torch
-//unsigned long size_type    Not Supported by torch
-//long double               Not Supported by torch
-//NSL::complex<int>         Not Supported by torch
-
 REAL_NSL_TEST_CASE( "Lattice: Ring", "[Lattice, Ring]" ) {
     const size_type size = GENERATE(2, 4, 8, 101, 202, 505, 1010);
     const TestType kappa = GENERATE(0.5, 2.0);
 
     test_ring<TestType>(size, kappa);
+    test_ring<NSL::complex<TestType>>(size, kappa);
+    test_ring<NSL::complex<TestType>>(size, NSL::complex<TestType>(kappa,kappa));
 }

--- a/Tests/Lattice/test_square.cpp
+++ b/Tests/Lattice/test_square.cpp
@@ -62,32 +62,27 @@ void test_cube(const size_type & size, T kappa = 1.){
 // Test Cases
 // =============================================================================
 
-TEST_CASE( "Lattice: 1D Square", "[Lattice, Square, 1D]" ) {
+REAL_NSL_TEST_CASE( "Lattice: 1D Square", "[Lattice, Square, 1D]" ) {
     const size_type d0 = GENERATE(2, 4, 8, 16);
 
     std::vector<size_type> n(1);
     n[0] = d0;
-    // floating point types
-    test_square<float>(n);
-    // Resolve https://github.com/Marcel-Rodekamp/NSL/issues/9 before implementing:
-    // test_square<NSL::complex<double>>(n, NSL::complex<double>(0.707, 0.707));
+    test_square<TestType>(n);
+    test_square<NSL::complex<TestType>>(n, NSL::complex<TestType>(0.707, 0.707));
 }
 
-TEST_CASE( "Lattice: 2D Square", "[Lattice, Square, 2D]" ) {
+REAL_NSL_TEST_CASE( "Lattice: 2D Square", "[Lattice, Square, 2D]" ) {
     const size_type d0 = GENERATE(2, 3, 4, 8, 16);
     const size_type d1 = GENERATE(2, 4, 5, 8, 16);
 
     std::vector<size_type> n(2);
     n[0] = d0;
     n[1] = d1;
-    // floating point types
-    test_square<float>(n);
-    test_square<double>(n);
-    // Resolve https://github.com/Marcel-Rodekamp/NSL/issues/9 before implementing:
-    // test_square<NSL::complex<double>>(n, NSL::complex<double>(0.707, 0.707));
+    test_square<TestType>(n);
+    test_square<NSL::complex<TestType>>(n, NSL::complex<TestType>(0.707, 0.707));
 }
 
-TEST_CASE( "Lattice: 3D Square", "[Lattice, Square, 3D]" ) {
+REAL_NSL_TEST_CASE( "Lattice: 3D Square", "[Lattice, Square, 3D]" ) {
     const size_type d0 = GENERATE(2, 3, 4, 8, 16);
     const size_type d1 = GENERATE(2, 4, 5, 8, 16);
     const size_type d2 = GENERATE(2, 4, 8, 9, 16);
@@ -96,19 +91,13 @@ TEST_CASE( "Lattice: 3D Square", "[Lattice, Square, 3D]" ) {
     n[0] = d0;
     n[1] = d1;
     n[2] = d2;
-    // floating point types
-    test_square<float>(n);
-    test_square<double>(n);
-    // Resolve https://github.com/Marcel-Rodekamp/NSL/issues/9 before implementing:
-    // test_square<NSL::complex<double>>(n, NSL::complex<double>(0.707, 0.707));
+    test_square<TestType>(n);
+    test_square<NSL::complex<TestType>>(n, NSL::complex<TestType>(0.707, 0.707));
 }
 
-TEST_CASE( "Lattice: Cube", "[Lattice, Cube, 3D]" ) {
+REAL_NSL_TEST_CASE( "Lattice: Cube", "[Lattice, Cube, 3D]" ) {
     const size_type n = GENERATE(2, 3, 4, 8, 16);
 
-    // floating point types
-    test_cube<float>(n);
-    test_cube<double>(n);
-    // Resolve https://github.com/Marcel-Rodekamp/NSL/issues/9 before implementing:
-    // test_cube<NSL::complex<double>>(n, NSL::complex<double>(0.707, 0.707));
+    test_cube<TestType>(n);
+    test_cube<NSL::complex<TestType>>(n, NSL::complex<TestType>(0.707, 0.707));
 }

--- a/src/NSL/CMakeLists.txt
+++ b/src/NSL/CMakeLists.txt
@@ -3,6 +3,7 @@ target_include_directories(NSL PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_sources(NSL PUBLIC
         assert.hpp
         complex.hpp
+        map.hpp
         )
 
 

--- a/src/NSL/Lattice/Implementations/ring.cpp
+++ b/src/NSL/Lattice/Implementations/ring.cpp
@@ -47,8 +47,7 @@ NSL::Lattice::Ring<Type>::Ring(const std::size_t n, const Type &kappa, const dou
 
 template class NSL::Lattice::Ring<float>;
 template class NSL::Lattice::Ring<double>;
-// Resolve https://github.com/Marcel-Rodekamp/NSL/issues/9 before implementing:
-//template class NSL::Lattice::Ring<NSL::complex<float>>;
-//template class NSL::Lattice::Ring<NSL::complex<double>>;
+template class NSL::Lattice::Ring<NSL::complex<float>>;
+template class NSL::Lattice::Ring<NSL::complex<double>>;
 
 #endif

--- a/src/NSL/Lattice/Implementations/square.cpp
+++ b/src/NSL/Lattice/Implementations/square.cpp
@@ -221,8 +221,7 @@ NSL::Lattice::Square<Type>::Square(
 
 template class NSL::Lattice::Square<float>;
 template class NSL::Lattice::Square<double>;
-// Resolve https://github.com/Marcel-Rodekamp/NSL/issues/9 before implementing:
-//template class NSL::Lattice::Square<NSL::complex<float>>;
-//template class NSL::Lattice::Square<NSL::complex<double>>;
+template class NSL::Lattice::Square<NSL::complex<float>>;
+template class NSL::Lattice::Square<NSL::complex<double>>;
 
 #endif

--- a/src/NSL/Lattice/lattice.cpp
+++ b/src/NSL/Lattice/lattice.cpp
@@ -146,5 +146,4 @@ void NSL::Lattice::SpatialLattice<Type>::compute_bipartite(){
 template class NSL::Lattice::SpatialLattice<float>;
 template class NSL::Lattice::SpatialLattice<double>;
 // Resolve https://github.com/Marcel-Rodekamp/NSL/issues/9 before implementing:
-//template class NSL::Lattice::SpatialLattice<NSL::complex<float>>;
-//template class NSL::Lattice::SpatialLattice<NSL::complex<double>>;
+template class NSL::Lattice::SpatialLattice<NSL::complex<float>>;

--- a/src/NSL/Lattice/lattice.cpp
+++ b/src/NSL/Lattice/lattice.cpp
@@ -145,5 +145,5 @@ void NSL::Lattice::SpatialLattice<Type>::compute_bipartite(){
 
 template class NSL::Lattice::SpatialLattice<float>;
 template class NSL::Lattice::SpatialLattice<double>;
-// Resolve https://github.com/Marcel-Rodekamp/NSL/issues/9 before implementing:
 template class NSL::Lattice::SpatialLattice<NSL::complex<float>>;
+template class NSL::Lattice::SpatialLattice<NSL::complex<double>>;

--- a/src/NSL/Lattice/lattice.hpp
+++ b/src/NSL/Lattice/lattice.hpp
@@ -13,7 +13,7 @@
 
 #include "../assert.hpp"
 #include "../complex.hpp"
-
+#include "../map.hpp"
 #include "../Tensor/tensor.hpp"
 
 namespace NSL::Lattice {
@@ -94,7 +94,7 @@ class SpatialLattice {
         //! The sites connectd by the hopping amplitudes.
         NSL::Tensor<double> sites_;
         //! Since exponentiating can be costly, a place to memoize results.
-        std::map<Type,NSL::Tensor<Type>> exp_hopping_matrix_;
+        NSL::map<Type,NSL::Tensor<Type>> exp_hopping_matrix_;
         //! Store whether the lattice can be bipartitioned.
         bool bipartite_ = false;
         //! We only check for bipartiteness on the first request.

--- a/src/NSL/map.hpp
+++ b/src/NSL/map.hpp
@@ -1,0 +1,84 @@
+#ifndef NANOSYSTEMLIBRARY_MAP_HPP
+#define NANOSYSTEMLIBRARY_MAP_HPP
+
+//! \file map.hpp
+
+#include "complex.hpp"
+
+namespace NSL {
+//! Helper struct for generalizing `std::map` to complex valued keys
+/*!
+ * `std::map<Key,T,Compare,Allocator>` is imported with
+ * ```
+ * MapHelper<...>::mapType;
+ * ```
+ * */
+template<
+        typename Key,
+        typename T,
+        class Compare = std::less<Key>,
+        class Allocator = std::allocator<std::pair<const Key, T>>
+>
+struct MapHelper {
+    using mapType = std::map<Key, T, Compare, Allocator>;
+};
+
+//! Helper struct for generalizing `std::map` to complex valued keys
+/*
+ * The Lexicographical Ordering can be used as
+ * ```
+ * MapHelper<std::complex<double>,void>::LexicographicLess myLess;
+ * bool b = myLess(std::complex<double>{0.,1.}, std::complex<double>{1.,0.});
+ * ```
+ *
+*/
+template<
+        typename RealTypeKey,
+        typename T
+>
+struct MapHelper<NSL::complex<RealTypeKey>, T> {
+    struct LexicographicLess {
+        bool operator()(NSL::complex<RealTypeKey> const &a, NSL::complex<RealTypeKey> const &b) const {
+            return std::array<RealTypeKey, 2>{a.real(), a.imag()} < std::array<RealTypeKey, 2>{b.real(), b.imag()};
+        }
+    };
+
+    using mapType = std::map<NSL::complex<RealTypeKey>, T, LexicographicLess>;
+};
+
+//! Generalization of `std::map` for complex valued Keys.
+/*!
+ * This alias is an import and extension for the `std::map`.
+ * For all typenames `Key` which are not `NSL::complex`, `NSL::map`  is equal to
+ * to `std::map` and has the same features as detailed here:
+ * https://en.cppreference.com/w/cpp/container/map
+ * if `Key` is `NSL::complex` the map is specialized to use a lexicographic
+ * ordering on the key:
+ * ```
+ * lhs < rhs iff
+ *      std::array{lhs.real(),lhs.imag()} < std::array{rhs.real(),rhs.imag()}
+ * ```
+ * which defines a weak order. For details see:
+ * https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
+ *
+ * This differentiation is conveniently done via partial template specialization.
+ * For non complex `Key`, `MapHelper<...>::mapType` simply imports `std::map`.
+ * For `Key == NSL::complex<RealTypeKey>` the ordering is the lexicographical one.
+ *
+ * This is used e.g. in `NSL::Lattice` to store the computed exponential hopping
+ * matrices together with the corresponding value of `delta` which in general
+ * might be complex valued.
+ * */
+template<
+        typename Key,
+        typename T,
+        class Compare = std::less<Key>,
+        class Allocator = std::allocator<std::pair<const Key, T>>
+>
+using map = MapHelper<Key, T, Compare, Allocator>::mapType;
+//pre c++20 we would have to use:
+//using map = typename MapHelper<Key,T>::mapType;
+
+} //namespace NSL
+
+#endif //NANOSYSTEMLIBRARY_MAP_HPP

--- a/src/NSL/map.hpp
+++ b/src/NSL/map.hpp
@@ -75,8 +75,9 @@ template<
         class Compare = std::less<Key>,
         class Allocator = std::allocator<std::pair<const Key, T>>
 >
-using map = MapHelper<Key, T, Compare, Allocator>::mapType;
-//pre c++20 we would have to use:
+using map = typename MapHelper<Key, T, Compare, Allocator>::mapType;
+// With clang ^ this typename is necessary, although with g++11 it is not.
+// Even with g++, before c++20 we would have to use:
 //using map = typename MapHelper<Key,T>::mapType;
 
 } //namespace NSL


### PR DESCRIPTION
Addresses 
 - #8: the complexes needed an ordering to be used as a key to an `std::map`.  An `NSL::map` has a specialization that sorts the complexes lexicographically.
 - #9: using `NSL::map` inside Lattice objects allows for complex amplitudes (it's really δ that's used as the key, but for simplicity, δ takes the type of the hopping matrix).  Adds template instantiations for the lattice base class, the ring, and square lattices.  The complete lattices are intentionally omitted; an explanatory comment is included there.

Tests:
 - Some tests of Lattice objects are implemented as `REAL_NSL_TEST_CASE`s that then test a real type and the associated complex type.  The reason to do this is that for complex types I want to pass a complex hopping amplitude.