### PR TITLE
Patched include from slice.hpp -> sliceObj.tpp

### DIFF
--- a/src/NSL/NSL.hpp
+++ b/src/NSL/NSL.hpp
@@ -7,7 +7,7 @@
 // Helpers
 #include "map.hpp"
 #include "paramPack.hpp"
-#include "slice.hpp"
+#include "sliceObj.tpp"
 
 #include "types.hpp"
 #include "complex.hpp"


### PR DESCRIPTION
This slipped through the PR #46.