### PR TITLE
Added matrix multiplication as NSL::Tensor::mat_mul

### DIFF
--- a/src/NSL/Tensor/Impl/matmul.tpp
+++ b/src/NSL/Tensor/Impl/matmul.tpp
@@ -1,0 +1,35 @@
+#ifndef NSL_TENSOR_IMPL_MAT_MUL_TPP
+#define NSL_TENSOR_IMPL_MAT_MUL_TPP
+
+#include "base.tpp"
+
+namespace NSL::TensorImpl{
+
+template <NSL::Concept::isNumber Type>
+class TensorMatmul:
+    virtual private NSL::TensorImpl::TensorBase<Type>
+{
+    public:
+    
+    //! Matrix multiplication
+    NSL::Tensor<Type> mat_mul(const NSL::Tensor<Type> & other){
+        this->data_ = torch::matmul(this->data_,other);
+        return NSL::Tensor<Type>(this);
+    }
+
+    //! Matrix multiplication
+    /*!
+     * \todo: Add propper type casting
+     * */
+    template<NSL::Concept::isNumber OtherType>
+    NSL::Tensor<Type> mat_mul(const NSL::Tensor<OtherType> & other){
+        this->data_ = torch::matmul(this->data_,other);
+        return NSL::Tensor<Type>(this);
+    }
+
+};
+
+} // namespace NSL::TensorImpl
+
+#endif //NSL_TENSOR_IMPL_MAT_MUL_TPP
+

--- a/src/NSL/Tensor/tensor.hpp
+++ b/src/NSL/Tensor/tensor.hpp
@@ -34,6 +34,7 @@
 #include "Tensor/Impl/matrixExp.tpp"
 #include "Tensor/Impl/trigonometric.tpp"
 #include "Tensor/Impl/reductions.tpp"
+#include "Tensor/Impl/matmul.tpp"
 
 namespace NSL{
 
@@ -60,7 +61,8 @@ class Tensor:
     public NSL::TensorImpl::TensorTrigonometric<Type>,
     public NSL::TensorImpl::TensorReductions<Type>,
     public NSL::TensorImpl::TensorExpand<Type>,
-    public NSL::TensorImpl::TensorShift<Type>
+    public NSL::TensorImpl::TensorShift<Type>,
+    public NSL::TensorImpl::TensorMatmul<Type>
 {
     public:
 


### PR DESCRIPTION
Simple `NSL::Tensor::mat_mul` in place. Type casting missing, but added as todo waiting for #33.