### PR TITLE
Fixing assignment of default constructed Tensors

### DIFF
--- a/Tests/Tensor/test_constructor.cpp
+++ b/Tests/Tensor/test_constructor.cpp
@@ -40,20 +40,11 @@ NSL_TEST_CASE("Tensor Default Constructor", "[Tensor,Default,Constructor]"){
     INFO("type: " + std::string(typeid(TestType).name()));
 
     // default constructor
-    // Creates a one element Tensor (scalar) filled with 0
+    // Creates a none element Tensor.
+    // The underlying torch::Tensor carries the property "not defined"
     NSL::Tensor<TestType> T;
-    TestType * T_ptr = T.data();
 
-    // check the value
-    REQUIRE(T_ptr[0] == static_cast<TestType>(0));
-    // check the dimension of the tensor
-    REQUIRE(T.dim() == 0);
-    // check the number of elements of the tensor
-    REQUIRE(T.numel() == 1);
-    // check the shape of the tensor
-    for(auto x: T.shape()){
-        REQUIRE(x == 1);
-    }
+    REQUIRE(!torch::Tensor(T).defined());
 }
 
 NSL_TEST_CASE("Tensor 1D Constructor", "[Tensor,1D,Constructor]"){

--- a/src/NSL/Tensor/Impl/base.tpp
+++ b/src/NSL/Tensor/Impl/base.tpp
@@ -25,14 +25,11 @@ class TensorBase {
      using RealType = typename NSL::RT_extractor<Type>::value_type;
 
     //! default constructor
-    TensorBase() = default;
-    /*
-    :
-        data_(torch::zeros({}, torch::TensorOptions().dtype<Type>()) ),
-        defaultConstructed(true)
+    TensorBase() :
+        data_(torch::zeros({}, torch::TensorOptions().dtype<Type>()) )
     {
         //std::cout << "NSL::Tensor()" << std::endl;
-    }*/
+    }
 
     //! D-dimensional constructor
     template<NSL::Concept::isIntegral ... SizeTypes>
@@ -137,7 +134,7 @@ class TensorBase {
 
     //! Underlying torch::Tensor holding the data
     torch::Tensor data_;
-
+    
     //! Translate D indices to linear index for memory access.
     template<NSL::Concept::isIntegral ... SizeTypes>
     NSL::size_t linearIndex_(const SizeTypes &... indices) const{

--- a/src/NSL/Tensor/Impl/base.tpp
+++ b/src/NSL/Tensor/Impl/base.tpp
@@ -25,11 +25,14 @@ class TensorBase {
      using RealType = typename NSL::RT_extractor<Type>::value_type;
 
     //! default constructor
-    TensorBase() :
-        data_(torch::zeros({}, torch::TensorOptions().dtype<Type>()) )
+    TensorBase() = default;
+    /*
+    :
+        data_(torch::zeros({}, torch::TensorOptions().dtype<Type>()) ),
+        defaultConstructed(true)
     {
         //std::cout << "NSL::Tensor()" << std::endl;
-    }
+    }*/
 
     //! D-dimensional constructor
     template<NSL::Concept::isIntegral ... SizeTypes>
@@ -134,7 +137,7 @@ class TensorBase {
 
     //! Underlying torch::Tensor holding the data
     torch::Tensor data_;
-    
+
     //! Translate D indices to linear index for memory access.
     template<NSL::Concept::isIntegral ... SizeTypes>
     NSL::size_t linearIndex_(const SizeTypes &... indices) const{

--- a/src/NSL/Tensor/Impl/base.tpp
+++ b/src/NSL/Tensor/Impl/base.tpp
@@ -25,11 +25,7 @@ class TensorBase {
      using RealType = typename NSL::RT_extractor<Type>::value_type;
 
     //! default constructor
-    TensorBase() :
-        data_(torch::zeros({}, torch::TensorOptions().dtype<Type>()) )
-    {
-        //std::cout << "NSL::Tensor()" << std::endl;
-    }
+    TensorBase() = default;
 
     //! D-dimensional constructor
     template<NSL::Concept::isIntegral ... SizeTypes>

--- a/src/NSL/Tensor/tensor.hpp
+++ b/src/NSL/Tensor/tensor.hpp
@@ -96,11 +96,7 @@ class Tensor:
     NSL::Tensor<Type> & operator=(const NSL::Tensor<Type> & other){
         // deep copy of other into this
         // by default GPU <-> is asynch on host site
-        if(this->data_.defined()){
-            this->data_.copy_(other,true);
-        } else {
-            this->data_ = other.data_.clone();
-        }
+        this->data_.copy_(other,true);
         return *this;
     }
 

--- a/src/NSL/Tensor/tensor.hpp
+++ b/src/NSL/Tensor/tensor.hpp
@@ -34,6 +34,7 @@
 #include "Tensor/Impl/matrixExp.tpp"
 #include "Tensor/Impl/trigonometric.tpp"
 #include "Tensor/Impl/reductions.tpp"
+#include <stdexcept>
 
 namespace NSL{
 
@@ -88,7 +89,13 @@ class Tensor:
     NSL::Tensor<Type> & operator=(const NSL::Tensor<OtherType> & other){
         // deep copy of other into this
         // by default GPU <-> is asynch on host site
-        this->data_.copy_(other,true);
+        if(this->data_.defined()){
+            this->data_.copy_(static_cast<NSL::Tensor<Type>>(other),true);
+        } else {
+            // \todo: Implement Type conversion
+            throw std::runtime_error("Type conversion not implemented yet");
+            // this->data_ = torch::clone(static_cast<NSL::Tensor<Type>>(other));
+        }
         return *this;
     }
 
@@ -96,7 +103,11 @@ class Tensor:
     NSL::Tensor<Type> & operator=(const NSL::Tensor<Type> & other){
         // deep copy of other into this
         // by default GPU <-> is asynch on host site
-        this->data_.copy_(other,true);
+        if(this->data_.defined()){
+            this->data_.copy_(other,true);
+        } else {
+            this->data_ = other.data_.clone();
+        }
         return *this;
     }
 
@@ -104,7 +115,11 @@ class Tensor:
     NSL::Tensor<Type> & operator=(const torch::Tensor & other){
         // deep copy of other into this
         // by default GPU <-> is asynch on host site
-        this->data_.copy_(other,true);
+        if(this->data_.defined()){
+            this->data_.copy_(other,true);
+        } else {
+            this->data_ = other.clone();
+        }
         return *this;
     }
 

--- a/src/NSL/Tensor/tensor.hpp
+++ b/src/NSL/Tensor/tensor.hpp
@@ -96,7 +96,11 @@ class Tensor:
     NSL::Tensor<Type> & operator=(const NSL::Tensor<Type> & other){
         // deep copy of other into this
         // by default GPU <-> is asynch on host site
-        this->data_.copy_(other,true);
+        if(this->data_.defined()){
+            this->data_.copy_(other,true);
+        } else {
+            this->data_ = other.data_.clone();
+        }
         return *this;
     }
 


### PR DESCRIPTION
Objects like `NSL::map` default construct a `NSL::Tensor` in order to assign them at a later point (see e.g. `NSL::Lattice::SpatialLattice::exp_hopping_matrix_`). The way default construction worked before prevented later assignment using the  `NSL::Tensor::operator=` as the shape of the target tensor  naturally doesn't match the shape of the source tensor.
In this PR a fix for this issue is provided. In order to do this the default construction is now updated to default constructing the underlying `torch::Tensor`. A default constructed `torch::Tensor` counts as "not defined", i.e. `torch::Tensor::defined` returns false. Leveraging this behavior the method `operator=` can check for defined-ness. If the `torch::Tensor` is already defined, the behavior remains unchanged if it is undefined, i.e. default constructed, a new memory space is created and the source Tensor is copied in it. The latter is not asynchronous!
