### PR TITLE
Feature/mixed random access

### DIFF
--- a/src/NSL/Tensor/Impl/randomAccess.tpp
+++ b/src/NSL/Tensor/Impl/randomAccess.tpp
@@ -3,6 +3,8 @@
 
 #include "base.tpp"
 #include "../../sliceObj.tpp"
+#include "../../paramPack.hpp"
+#include <type_traits>
 
 
 namespace NSL::TensorImpl {
@@ -12,6 +14,26 @@ class TensorRandomAccess:
     virtual private NSL::TensorImpl::TensorBase<Type>
 {
     public:
+
+    //! Random Access operator
+    /*!
+     * \param indexer, pack of `NSL::Slice` and `NSL::size_t` types. 
+     * 
+     * This indexer mixes the usage of `NSL::Slice` and `NSL::size_t`
+     * to have a simpler access on a particular slice of a axis.
+     * */
+    template<NSL::Concept::isIndexer... IndexTypes>
+        // use only if NSL::size_t in IndexTypes and NSL::Slice in IndexTypes
+        requires NSL::packContains<NSL::Slice,IndexTypes...>::value && NSL::packContainsConvertible<NSL::size_t,IndexTypes...>::value 
+    NSL::Tensor<Type> operator()(IndexTypes ... indexer) 
+    {
+        return std::move(
+            this->data_.index(
+                std::initializer_list{torch::indexing::TensorIndex(indexer)...}
+            )
+        );
+    }
+    
     //! Random Access Operator
     /*!
     *  \param indices: `NSL::size_t`, Indices for each dimension of the tensor

--- a/src/NSL/concepts.hpp
+++ b/src/NSL/concepts.hpp
@@ -4,6 +4,7 @@
 #include<concepts>
 #include <type_traits>
 #include "complex.hpp"
+#include "sliceObj.tpp"
 
 namespace NSL::Concept{
 
@@ -78,8 +79,14 @@ concept isFloatingPoint = requires(T t) {
     isComplex<T> || std::is_floating_point_v<T>;
 };
 
+//! Concept to check for integers or `NSL::Slice`
+/*!
+ * */
+template<typename T>
+concept isIndexer = requires(T t) {
+    isIntegral<T> || std::is_same<T,NSL::Slice>::value;
+};
 
-
-} // namespace NSL::CONCEP 
+} // namespace NSL::Concept 
 
 #endif //NSL_CONCEPTS_HPP

--- a/src/NSL/paramPack.hpp
+++ b/src/NSL/paramPack.hpp
@@ -43,6 +43,19 @@ constexpr std::array<int, sizeof...(Types)> enumPack(Types ...args) {
     return std::array<int, sizeof...(args)>{(enumer(args))...};
 }
 
+//! Check if a type is contained in parameter pack
+template<typename T, typename ...Ts>
+struct packContains{
+    static constexpr bool value = (std::is_same<T, Ts>::value || ...);
+};
+
+//! Check if a type is contained in parameter pack
+template<typename T, typename ...Ts>
+struct packContainsConvertible{
+    static constexpr bool value = (std::is_convertible<T, Ts>::value || ...);
+};
+
+
 } // namespace NSL
 
 #endif // NSL_PARAMETERPACKHELPERS_HPP


### PR DESCRIPTION
Added mixed access to `NSL::Tensor`. Python like indexing
```
A[0,:,:]
```
is now accessible via
```
A(0,NSL::Slice(),NSL::Slice());
```