### PR TITLE
Hotfix/tensor member return types

### DIFF
--- a/src/NSL/Tensor/Impl/operatorAddition.tpp
+++ b/src/NSL/Tensor/Impl/operatorAddition.tpp
@@ -5,18 +5,20 @@
 
 namespace NSL{
 
+//! \todo: Add proper type casting!
+
 template<typename SelfType,typename OtherType>
-inline NSL::Tensor<bool> operator+(const NSL::Tensor<SelfType> & self, const NSL::Tensor<OtherType> & other) {
+inline NSL::Tensor<SelfType> operator+(const NSL::Tensor<SelfType> & self, const NSL::Tensor<OtherType> & other) {
     return torch::Tensor(self) + torch::Tensor(other);
 }
 
 template<NSL::Concept::isNumber ValueType,typename TensorType>
-inline NSL::Tensor<bool> operator+(const NSL::Tensor<TensorType> & tensor, const ValueType & value) {
+inline NSL::Tensor<TensorType> operator+(const NSL::Tensor<TensorType> & tensor, const ValueType & value) {
     return torch::Tensor(tensor) + value;
 }
 
 template<NSL::Concept::isNumber ValueType,typename TensorType>
-inline NSL::Tensor<bool> operator+(const ValueType & value, const NSL::Tensor<TensorType> & tensor) {
+inline NSL::Tensor<TensorType> operator+(const ValueType & value, const NSL::Tensor<TensorType> & tensor) {
     // calls above
     return tensor + value;
 }

--- a/src/NSL/Tensor/Impl/operatorDivision.tpp
+++ b/src/NSL/Tensor/Impl/operatorDivision.tpp
@@ -5,18 +5,21 @@
 
 namespace NSL{
 
+//! \todo Add propper Type casting
+
+
 template<typename SelfType,typename OtherType>
-inline NSL::Tensor<bool> operator/(const NSL::Tensor<SelfType> & self, const NSL::Tensor<OtherType> & other) {
+inline NSL::Tensor<SelfType> operator/(const NSL::Tensor<SelfType> & self, const NSL::Tensor<OtherType> & other) {
     return torch::Tensor(self) / torch::Tensor(other);
 }
 
 template<NSL::Concept::isNumber ValueType,typename TensorType>
-inline NSL::Tensor<bool> operator/(const NSL::Tensor<TensorType> & tensor, const ValueType & value) {
+inline NSL::Tensor<TensorType> operator/(const NSL::Tensor<TensorType> & tensor, const ValueType & value) {
     return torch::Tensor(tensor) / value;
 }
 
 template<NSL::Concept::isNumber ValueType,typename TensorType>
-inline NSL::Tensor<bool> operator/(const ValueType & value, const NSL::Tensor<TensorType> & tensor) {
+inline NSL::Tensor<TensorType> operator/(const ValueType & value, const NSL::Tensor<TensorType> & tensor) {
     // calls above
     return value / torch::Tensor(tensor);
 }

--- a/src/NSL/Tensor/Impl/operatorSubtraction.tpp
+++ b/src/NSL/Tensor/Impl/operatorSubtraction.tpp
@@ -5,18 +5,20 @@
 
 namespace NSL{
 
+//! \todo Add propper Type casting
+
 template<typename SelfType,typename OtherType>
-inline NSL::Tensor<bool> operator-(const NSL::Tensor<SelfType> & self, const NSL::Tensor<OtherType> & other) {
+inline NSL::Tensor<SelfType> operator-(const NSL::Tensor<SelfType> & self, const NSL::Tensor<OtherType> & other) {
     return torch::Tensor(self) - torch::Tensor(other);
 }
 
 template<NSL::Concept::isNumber ValueType,typename TensorType>
-inline NSL::Tensor<bool> operator-(const NSL::Tensor<TensorType> & tensor, const ValueType & value) {
+inline NSL::Tensor<TensorType> operator-(const NSL::Tensor<TensorType> & tensor, const ValueType & value) {
     return torch::Tensor(tensor) - value;
 }
 
 template<NSL::Concept::isNumber ValueType,typename TensorType>
-inline NSL::Tensor<bool> operator-(const ValueType & value, const NSL::Tensor<TensorType> & tensor) {
+inline NSL::Tensor<TensorType> operator-(const ValueType & value, const NSL::Tensor<TensorType> & tensor) {
     // calls above
     return (-1)*tensor+value;
 }


### PR DESCRIPTION
I had some mistakes in the return type of some operators caused by copying a file layout.