### PR TITLE
Feature/fermion matrix exp shift

### DIFF
--- a/Tests/FermionMatrix/test_fermionMatrixHubbardExp.cpp
+++ b/Tests/FermionMatrix/test_fermionMatrixHubbardExp.cpp
@@ -148,7 +148,7 @@ void test_fermionMatrixHubbardExp_M(const NSL::size_t nt, LatticeType & Lattice,
 
     // anti-periodic boundary condition
     out.transpose();
-    out.shift(0,1);
+    out.shift(1,0);
 
     out.slice(0,0,1)*=-1;
     NSL::Tensor<Type> result_exa = psi - out;

--- a/src/NSL/FermionMatrix/Impl/hubbardExp.tpp
+++ b/src/NSL/FermionMatrix/Impl/hubbardExp.tpp
@@ -27,7 +27,7 @@ NSL::Tensor<Type> NSL::FermionMatrix::HubbardExp<Type,LatticeType>::F_(const NSL
     // Now Fpsi contains
     // [\exp(δK)]_{xy} (\exp(i φ_{iy}) \psi_{yi})
     // What remains is to shift it
-    Fpsi.shift(0,1);
+    Fpsi.shift(1,0);
     // and apply B
     Fpsi(0,NSL::Slice()) *= -1;
 
@@ -70,7 +70,7 @@ NSL::Tensor<Type> NSL::FermionMatrix::HubbardExp<Type,LatticeType>::Mdagger(cons
       *                          |- element-wise * -->|------- shift ------|
       **/
 
-    return psi - ( NSL::conj(this->phiExp_) * (BexpKpsi.shift(0,-1)));
+    return psi - ( NSL::conj(this->phiExp_) * (BexpKpsi.shift(-1,0)));
 }
 
 template<NSL::Concept::isNumber Type, NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType>
@@ -93,7 +93,7 @@ NSL::Tensor<Type> NSL::FermionMatrix::HubbardExp<Type,LatticeType>::MMdagger(con
       **/
     return (this->M(psi) + this->Mdagger(psi) - psi) + NSL::LinAlg::mat_vec(
         this->Lat.exp_hopping_matrix(delta_),
-        (   NSL::LinAlg::shift(this->phiExp_ * NSL::conj(this->phiExp_), 0, +1)
+        (   NSL::LinAlg::shift(this->phiExp_ * NSL::conj(this->phiExp_), +1, 0)
           * NSL::LinAlg::mat_vec(
                 this->Lat.exp_hopping_matrix(NSL::conj(delta_)),
                 NSL::LinAlg::transpose(psi)


### PR DESCRIPTION
`shift(1,0)` on a matrix results in a shift in +1 direction in dim 0, whereas `shift(0,1)` on a matrix results in no shift (shift 0 in dim 1). Hence, replaced all the `shift(0,x)` (where x = +/- 1) with `shift(x,0)` in `src/NSL/FermionMatrix/Impl/hubbardExp.tpp`
 and `Tests/FermionMatrix/test_fermionMatrixHubbardExp.cpp` 
