### PR TITLE
No lattice cpps

### DIFF
--- a/src/NSL/CMakeLists.txt
+++ b/src/NSL/CMakeLists.txt
@@ -1,20 +1,5 @@
 # relative include to the src/
 target_include_directories(NSL PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
-target_sources(NSL PRIVATE
-    assert.hpp
-    complex.hpp
-    concepts.hpp
-    FermionMatrix.hpp
-    Lattice.hpp
-    LinAlg.hpp
-    map.hpp
-    Matrix.hpp
-    NSL.hpp
-    paramPack.hpp
-    sliceObj.tpp
-    Tensor.hpp
-    types.hpp
-)
 
 # add the tensor class
 add_subdirectory(Tensor/)

--- a/src/NSL/Lattice.hpp
+++ b/src/NSL/Lattice.hpp
@@ -2,8 +2,8 @@
 #define NSL_LATTICE_INCLUDE_HPP
 
 #include "Lattice/lattice.hpp"
-#include "Lattice/Implementations/ring.hpp"
-#include "Lattice/Implementations/square.hpp"
-#include "Lattice/Implementations/complete.hpp"
+#include "Lattice/Implementations/ring.tpp"
+#include "Lattice/Implementations/square.tpp"
+#include "Lattice/Implementations/complete.tpp"
 
 #endif

--- a/src/NSL/Lattice.hpp
+++ b/src/NSL/Lattice.hpp
@@ -1,7 +1,7 @@
 #ifndef NSL_LATTICE_INCLUDE_HPP
 #define NSL_LATTICE_INCLUDE_HPP
 
-#include "Lattice/lattice.hpp"
+#include "Lattice/lattice.tpp"
 #include "Lattice/Implementations/ring.tpp"
 #include "Lattice/Implementations/square.tpp"
 #include "Lattice/Implementations/complete.tpp"

--- a/src/NSL/Lattice/CMakeLists.txt
+++ b/src/NSL/Lattice/CMakeLists.txt
@@ -1,6 +1,1 @@
-target_sources(NSL PRIVATE
-        lattice.hpp
-        lattice.cpp
-)
-
 add_subdirectory(Implementations/)

--- a/src/NSL/Lattice/Implementations/CMakeLists.txt
+++ b/src/NSL/Lattice/Implementations/CMakeLists.txt
@@ -1,8 +1,1 @@
-target_sources(NSL PRIVATE
-    ring.hpp
-    ring.cpp
-    square.hpp
-    square.cpp
-    complete.hpp
-    complete.cpp
-)
+

--- a/src/NSL/Lattice/Implementations/complete.tpp
+++ b/src/NSL/Lattice/Implementations/complete.tpp
@@ -1,3 +1,5 @@
+#ifndef NSL_LATTICE_COMPLETE_TPP
+#define NSL_LATTICE_COMPLETE_TPP
 /*! \file complete.cpp
 */
 
@@ -38,3 +40,4 @@ NSL::Lattice::Complete<Type>::Complete(const std::size_t n, const Type &kappa, c
 }
 
 } // namespace NSL::Lattice
+#endif //NSL_LATTICE_COMPLETE_TPP

--- a/src/NSL/Lattice/Implementations/complete.tpp
+++ b/src/NSL/Lattice/Implementations/complete.tpp
@@ -38,13 +38,3 @@ NSL::Lattice::Complete<Type>::Complete(const std::size_t n, const Type &kappa, c
 }
 
 } // namespace NSL::Lattice
-
-template class NSL::Lattice::Complete<float>;
-template class NSL::Lattice::Complete<double>;
-// There's no way to make obvious sense of complex hopping.
-// There's not even a way to pick a convention, since every site
-// connects to every other site!
-// But, for compatibility with FermionMatrix, which wants complex types, we implement them anyway.
-// See issue #70
-template class NSL::Lattice::Complete<NSL::complex<float>>;
-template class NSL::Lattice::Complete<NSL::complex<double>>;

--- a/src/NSL/Lattice/Implementations/ring.tpp
+++ b/src/NSL/Lattice/Implementations/ring.tpp
@@ -35,8 +35,3 @@ NSL::Lattice::Ring<Type>::Ring(const std::size_t n, const Type &kappa, const dou
 }
 
 } // namespace NSL::Lattice
-
-template class NSL::Lattice::Ring<float>;
-template class NSL::Lattice::Ring<double>;
-template class NSL::Lattice::Ring<NSL::complex<float>>;
-template class NSL::Lattice::Ring<NSL::complex<double>>;

--- a/src/NSL/Lattice/Implementations/ring.tpp
+++ b/src/NSL/Lattice/Implementations/ring.tpp
@@ -1,3 +1,6 @@
+#ifndef NSL_LATTICE_RING_TPP
+#define NSL_LATTICE_RING_TPP
+
 #include "ring.hpp"
 
 namespace NSL::Lattice {
@@ -35,3 +38,5 @@ NSL::Lattice::Ring<Type>::Ring(const std::size_t n, const Type &kappa, const dou
 }
 
 } // namespace NSL::Lattice
+
+#endif

--- a/src/NSL/Lattice/Implementations/square.tpp
+++ b/src/NSL/Lattice/Implementations/square.tpp
@@ -1,3 +1,7 @@
+#ifndef NSL_LATTICE_SQUARE_TPP
+#define NSL_LATTICE_SQUARE_TPP
+
+
 /*! \file square.cpp
  *  \author Evan Berkowitz
  *  \date October 2021
@@ -214,3 +218,4 @@ NSL::Lattice::Square<Type>::Square(
 }
 
 } // namespace NSL::Lattice
+#endif //NSL_LATTICE_SQUARE_HPP

--- a/src/NSL/Lattice/Implementations/square.tpp
+++ b/src/NSL/Lattice/Implementations/square.tpp
@@ -214,8 +214,3 @@ NSL::Lattice::Square<Type>::Square(
 }
 
 } // namespace NSL::Lattice
-
-template class NSL::Lattice::Square<float>;
-template class NSL::Lattice::Square<double>;
-template class NSL::Lattice::Square<NSL::complex<float>>;
-template class NSL::Lattice::Square<NSL::complex<double>>;

--- a/src/NSL/Lattice/lattice.tpp
+++ b/src/NSL/Lattice/lattice.tpp
@@ -1,3 +1,5 @@
+#ifndef NSL_LATTICE_TPP
+#define NSL_LATTICE_TPP
 #include "lattice.hpp"
 
 namespace NSL::Lattice {
@@ -123,3 +125,4 @@ void NSL::Lattice::SpatialLattice<Type>::compute_bipartite(){
 }
 
 } // namespace NSL
+#endif // NSL_LATTICE_TPP

--- a/src/NSL/Lattice/lattice.tpp
+++ b/src/NSL/Lattice/lattice.tpp
@@ -123,8 +123,3 @@ void NSL::Lattice::SpatialLattice<Type>::compute_bipartite(){
 }
 
 } // namespace NSL
-
-template class NSL::Lattice::SpatialLattice<float>;
-template class NSL::Lattice::SpatialLattice<double>;
-template class NSL::Lattice::SpatialLattice<NSL::complex<float>>;
-template class NSL::Lattice::SpatialLattice<NSL::complex<double>>;


### PR DESCRIPTION
We've had a long-standing aim to go header-only.  A few advantages, but one is that recompilation after a change is needed less often.

The only obstacles were the explicit implementations of a few lattice objects.

This commit 
 - changes all the lattice cpps into tpps,
 - adds previously-unneeded include guards to the tpps,
 - removes many .hpp and .tpp `target_sources` from CMake files.

This is one step towards resolving #70.