### PR TITLE
Logging with spdlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ build
 
 # vim swap files
 *.swp
+
+# Log files
+*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ include(cmake/ARM64.cmake)
 #include(cmake/gpu.cmake)
 include(cmake/torch.cmake)
 include(cmake/catch2.cmake)
-
+include(cmake/spdlog.cmake)
 
 add_subdirectory(src/NSL)
 

--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -1,0 +1,11 @@
+FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog.git
+        GIT_TAG        v1.11.0
+)
+
+FetchContent_GetProperties(spdlog)
+if (NOT spdlog_POPULATED)
+    FetchContent_Populate(spdlog)
+    add_subdirectory(${spdlog_SOURCE_DIR} ${spdlog_BINARY_DIR})
+endif ()

--- a/src/NSL/CMakeLists.txt
+++ b/src/NSL/CMakeLists.txt
@@ -1,2 +1,3 @@
 # relative include to the src/
 target_include_directories(NSL PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(NSL spdlog::spdlog)

--- a/src/NSL/MarkovChain/HMC.tpp
+++ b/src/NSL/MarkovChain/HMC.tpp
@@ -74,6 +74,7 @@ class HMC{
             double runningAcceptence = 1.;
 
             // generate Nconf-1 configurations
+            auto mc_time = NSL::Logger::start_profile("HMC");
             for(NSL::size_t n = 1; n < Nconf; ++n){
                 auto tmp = MC[n-1];
                 
@@ -89,15 +90,11 @@ class HMC{
 
                 // ToDo: have a proper hook being called here
                 if (n % logFrequency == 0){
-                    std::cout << "HMC: "
-                              << n 
-                              << "/"
-                              << Nconf 
-                              << "; Running Acceptence Rate: " 
-                              << runningAcceptence*100/n
-                              << "% \n";
+                    NSL::Logger::info("HMC: {}/{}; Running Acceptence Rate: {:.6}%", n, Nconf, runningAcceptence*100/n);
+                    NSL::Logger::elapsed_profile(mc_time);
                 }
             }
+            NSL::Logger::stop_profile(mc_time);
 
             // return the Markov Chain
             return MC;

--- a/src/NSL/NSL.hpp
+++ b/src/NSL/NSL.hpp
@@ -11,6 +11,7 @@
 #include "typePromotion.hpp"
 #include "types.hpp"
 #include "complex.hpp"
+#include "logger.hpp"
 
 // NSL
 #include "Tensor.hpp"

--- a/src/NSL/logger.hpp
+++ b/src/NSL/logger.hpp
@@ -42,7 +42,7 @@ namespace NSL::Logger {
                 case 'l':
                     log_level = std::string(optarg);
                     if(!levels.contains(log_level)) {   
-                        std::cerr << "Improper usage of --log-level (-l) flag. Expected one of:\n";
+                        std::cerr << "Improper usage of -l flag. Expected one of:\n";
                         std::cerr << "- debug (prints debug information)\n";
                         std::cerr << "- info  (prints regular run information) [DEFAULT]\n";
                         std::cerr << "- warn  (prints warnings and errors only)\n";
@@ -54,14 +54,14 @@ namespace NSL::Logger {
                     break;
                 case '?':
                     if (optopt == 'l'){   
-                        std::cerr << "Improper usage of --log-level (-l) flag. Expected one of:\n";
+                        std::cerr << "Improper usage of -l flag. Expected one of:\n";
                         std::cerr << "- debug (prints debug information)\n";
                         std::cerr << "- info  (prints regular run information) [DEFAULT]\n";
                         std::cerr << "- warn  (prints warnings and errors only)\n";
                         std::cerr << "- error (prints errors only)\n";
                     }
                     else if (optopt == 'o'){   
-                        std::cerr << "Improper usage of --log-file (-o) flag. Expected output log filename:\n";
+                        std::cerr << "Improper usage of -o flag. Expected output log filename:\n";
                     }
                     else isprint (optopt);
                     exit(1);

--- a/src/NSL/logger.hpp
+++ b/src/NSL/logger.hpp
@@ -1,0 +1,140 @@
+#ifndef NSL_LOGGER_INCLUDE_HPP
+#define NSL_LOGGER_INCLUDE_HPP
+
+#include <iostream>
+#include <unistd.h>
+#include <map>
+#include <utility>
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/stopwatch.h>
+
+/*! \file logger.hpp
+ *  Utilities for logging to console and files
+ *
+ *  The main strategy is to have a singleton that handles parameters form 
+ *  command line and sets up the appropriate logger.
+ *    
+ **/
+
+namespace NSL::Logger {
+    
+    static bool do_profile = false;
+
+    inline void init_logger(int argc, char* argv[]){
+        int opt;
+        std::string log_level = "info";
+        std::string log_file = "";
+
+        std::map<std::string, spdlog::level::level_enum> levels = {
+            {"debug", spdlog::level::debug},
+            {"info", spdlog::level::info},
+            {"warn", spdlog::level::warn},
+            {"error", spdlog::level::err},
+        };
+
+        while ((opt = getopt (argc, argv, "l:o:p")) != -1){
+            switch (opt){
+                case 'p':
+                    do_profile = true;
+                    break;
+                case 'l':
+                    log_level = std::string(optarg);
+                    if(!levels.contains(log_level)) {   
+                        std::cerr << "Improper usage of --log-level (-l) flag. Expected one of:\n";
+                        std::cerr << "- debug (prints debug information)\n";
+                        std::cerr << "- info  (prints regular run information) [DEFAULT]\n";
+                        std::cerr << "- warn  (prints warnings and errors only)\n";
+                        std::cerr << "- error (prints errors only)\n";
+                    }
+                    break;
+                case 'o':
+                    log_file = std::string(optarg);
+                    break;
+                case '?':
+                    if (optopt == 'l'){   
+                        std::cerr << "Improper usage of --log-level (-l) flag. Expected one of:\n";
+                        std::cerr << "- debug (prints debug information)\n";
+                        std::cerr << "- info  (prints regular run information) [DEFAULT]\n";
+                        std::cerr << "- warn  (prints warnings and errors only)\n";
+                        std::cerr << "- error (prints errors only)\n";
+                    }
+                    else if (optopt == 'o'){   
+                        std::cerr << "Improper usage of --log-file (-o) flag. Expected output log filename:\n";
+                    }
+                    else isprint (optopt);
+                    exit(1);
+                default:
+                    abort ();
+            }
+        }
+
+        std::vector<spdlog::sink_ptr> sinks;
+        if(log_file != ""){
+            auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(log_file, true);
+            file_sink->set_level(levels["debug"]);
+            sinks.push_back(file_sink);
+        }
+
+        auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+        console_sink->set_level(levels[log_level]);
+        sinks.push_back(console_sink);
+
+        auto logger = std::make_shared<spdlog::logger>("NSL_logger", begin(sinks), end(sinks));
+        logger->set_pattern("[%D %T] [%l] %v");
+
+        spdlog::register_logger(logger);
+        spdlog::set_default_logger(logger);
+
+        if(do_profile){
+            auto profile_logger = spdlog::basic_logger_st("NSL_profiler", "NSL_profile.log", true);
+            profile_logger->set_pattern("[%D %T] %v");
+        }
+    }
+
+
+    template <typename... Args>
+    inline void debug(fmt::format_string<Args...> fmt, Args&&... args){
+        spdlog::debug(fmt, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    inline void info(fmt::format_string<Args...> fmt, Args&&... args){
+        spdlog::info(fmt, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    inline void warn(fmt::format_string<Args...> fmt, Args&&... args){
+        spdlog::warn(fmt, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    inline void error(fmt::format_string<Args...> fmt, Args&&... args){
+        spdlog::error(fmt, std::forward<Args>(args)...);
+    }
+
+    inline std::pair<spdlog::stopwatch, std::string> start_profile(const std::string& tag){
+        if(do_profile){
+            spdlog::get("NSL_profiler")->warn("Entering {}", tag);
+        }
+        return std::make_pair(spdlog::stopwatch(), tag);
+    }
+
+    inline void elapsed_profile(const std::pair<spdlog::stopwatch, std::string>& sw){
+        if(do_profile){
+            spdlog::get("NSL_profiler")->warn("Time since start of {}: {:.3} s", sw.second, sw.first);
+        }
+    }
+
+    inline void stop_profile(const std::pair<spdlog::stopwatch, std::string>& sw){
+        if(do_profile){
+            spdlog::get("NSL_profiler")->warn("Total time spent in {}: {:.3} s", sw.second, sw.first);
+        }
+    }
+
+
+} // namespace NSL::Logger
+
+
+#endif

--- a/src/NSL/logger.hpp
+++ b/src/NSL/logger.hpp
@@ -83,6 +83,7 @@ namespace NSL::Logger {
 
         auto logger = std::make_shared<spdlog::logger>("NSL_logger", begin(sinks), end(sinks));
         logger->set_pattern("[%D %T] [%l] %v");
+        logger->flush_on(spdlog::level::debug);
 
         spdlog::register_logger(logger);
         spdlog::set_default_logger(logger);
@@ -90,6 +91,7 @@ namespace NSL::Logger {
         if(do_profile){
             auto profile_logger = spdlog::basic_logger_st("NSL_profiler", "NSL_profile.log", true);
             profile_logger->set_pattern("[%D %T] %v");
+            profile_logger->flush_on(spdlog::level::debug);
         }
     }
 


### PR DESCRIPTION
Added support for logging and a unified way to print to standard output. 
CMake should download the most recent (as of today) release version of spdlog, this is tested and will remain fixed unless changed in the `cmake/spdlog.cmake` file.
Three command line options are available:
  -l <level>: to control the level of logging, by default it is "info"
  -p : toggles profiling, this will generate a file "NSL_profile.log" with timing information
  -o <filename>: toggles file logging, default is no file output, only standard output
