### PR TITLE
fix logger debug level not working

### DIFF
--- a/src/NSL/logger.hpp
+++ b/src/NSL/logger.hpp
@@ -83,6 +83,7 @@ namespace NSL::Logger {
 
         auto logger = std::make_shared<spdlog::logger>("NSL_logger", begin(sinks), end(sinks));
         logger->set_pattern("[%D %T] [%l] %v");
+        logger->set_level(spdlog::level::debug);
         logger->flush_on(spdlog::level::debug);
 
         spdlog::register_logger(logger);


### PR DESCRIPTION
This is just a one line fix to allow the logger to work with debug level. Apparently if you set the levels on the sink objects, the logger object still filters them out depending on its own intrinsic level (which is info by default). So I just changed it to debug by default.

(Should we make hotfixes not go through pull requests if they are small enough?)