### PR TITLE
Feature/honeycomb

### DIFF
--- a/Executables/Examples/CMakeLists.txt
+++ b/Executables/Examples/CMakeLists.txt
@@ -10,3 +10,6 @@ target_link_libraries(example_MCMC NSL)
 add_executable(example_leapfrog example_leapfrog.cpp)
 target_link_libraries(example_leapfrog NSL)
 
+add_executable(example_honeycomb example_honeycomb.cpp)
+target_link_libraries(example_honeycomb NSL)
+

--- a/Executables/Examples/example_honeycomb.cpp
+++ b/Executables/Examples/example_honeycomb.cpp
@@ -1,0 +1,44 @@
+#include <chrono>
+#include "NSL.hpp"
+
+int main(int argc, char* argv[]){
+
+    NSL::Logger::init_logger(argc, argv);
+
+    // We'll loop over different combinations of L1 and L2 drawn from this set.
+	//! \todo: This branch doesn't have HDF5 yet, so I'll just do one small example.
+	// The hopping matrix of L=(3,3) is small enough to copy/paste and reformat by hand.
+    std::set<int> LS = {3,};
+	// When we can use HDF5 it'd be good to generate a variety of lattices, such as
+    // std::set<int> LS = {3, 4, 5, 6, 9, 12, 15};
+	double kappa = 1.0;
+
+	// Now with a file named 
+	//std::string filename = "./example_honeycomb.h5";
+	// we create the HDF5 file
+
+    for(auto L1: LS){
+        for(auto L2: LS){
+
+			std::vector<int> L = {L1, L2};
+
+            NSL::Logger::info("Creating a honeycomb lattice with L1={}, L2={}...", L1, L2);
+            NSL::Lattice::Honeycomb<double> lattice(L, kappa);
+            NSL::Logger::info("... computing hopping matrix...");
+			NSL::Tensor<double> hopping = lattice.hopping_matrix();
+
+			// Here we write out the hopping matrix;
+            std::cout << hopping << std::endl;
+
+			// It'd be better to just
+            //NSL::Logger::info("... writing to {} ...", filename);
+			// and write to eg. /L1/L2/hopping
+			// We could write the coordinates out too, for visualization.
+
+        }
+    }
+
+    
+
+    return EXIT_SUCCESS;
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_NSL_test(test_bipartite Lattice/test_bipartite.cpp)
 add_NSL_test(test_complete Lattice/test_complete.cpp)
 add_NSL_test(test_ring Lattice/test_ring.cpp)
 add_NSL_test(test_square Lattice/test_square.cpp)
+add_NSL_test(test_honeycomb Lattice/test_honeycomb.cpp)
 
 add_NSL_test(test_FermionMatrix_hermitian FermionMatrix/test_FermionMatrix_hermitian.cpp)
 add_NSL_test(test_fermionMatrixHubbardExp FermionMatrix/test_fermionMatrixHubbardExp.cpp)

--- a/Tests/Lattice/test_honeycomb.cpp
+++ b/Tests/Lattice/test_honeycomb.cpp
@@ -1,0 +1,64 @@
+#include "../test.hpp"
+
+/*! \file test_square.cpp
+ *  Test the `Lattice::Square` implementation.
+ */
+
+//! Torch requirement
+using size_type = int;
+
+/*!
+ *  \param size the number of sites
+ *  \param kappa the counter-clockwise hopping amplitude
+ **/
+template<typename T>
+void test_honeycomb_volume(NSL::Lattice::Honeycomb<T> & lattice){
+    // 2 sites per unit cell
+    REQUIRE(lattice.sites() == 2*lattice.unit_cells);
+}
+
+template<typename T>
+void test_honeycomb_valence(NSL::Lattice::Honeycomb<T> & lattice){
+    // each vertex is valence 3
+    INFO( lattice.adjacency_matrix().sum(0) );
+    REQUIRE( (lattice.adjacency_matrix().sum(0) == 3).all() );
+    INFO( lattice.adjacency_matrix().sum(1) );
+    REQUIRE( (lattice.adjacency_matrix().sum(1) == 3).all() );
+}
+
+template<typename T>
+void test_honeycomb_hermiticity(NSL::Lattice::Honeycomb<T> & lattice){
+    // The hopping matrix is Hermitian
+    NSL::Tensor<T> K = lattice.hopping_matrix();
+    REQUIRE( ((K - K.conj().transpose(0,1)) == 0).all() );
+}
+
+// =============================================================================
+// Test Cases
+// =============================================================================
+
+REAL_NSL_TEST_CASE( "Lattice: Honeycomb", "[Lattice, Honeycomb]" ) {
+    const size_type L1 = GENERATE(2, 3, 4, 6, 12, 15);
+    //const size_type L2 = GENERATE(2, 3, 4, 6, 12, 15);
+    const size_type L2 = L1;
+
+    std::vector<size_type> L(2);
+    L[0] = L1;
+    L[1] = L2;
+
+    INFO("Type = " << typeid(TestType).name());
+    INFO("L    = " << L);
+
+    NSL::Lattice::Honeycomb<TestType> lattice(L);
+
+    INFO(lattice.name());
+    INFO(lattice.sites());
+    INFO(lattice.coordinates());
+    INFO(lattice.adjacency_matrix());
+    
+    test_honeycomb_volume<TestType>(lattice);
+    test_honeycomb_valence<TestType>(lattice);
+    test_honeycomb_hermiticity<TestType>(lattice);
+    //! \todo: Add a test of the spectrum; Dirac points should only show up when L%3 = 0.
+}
+

--- a/src/NSL/Lattice.hpp
+++ b/src/NSL/Lattice.hpp
@@ -5,5 +5,6 @@
 #include "Lattice/Implementations/ring.tpp"
 #include "Lattice/Implementations/square.tpp"
 #include "Lattice/Implementations/complete.tpp"
+#include "Lattice/Implementations/honeycomb.tpp"
 
 #endif

--- a/src/NSL/Lattice/Implementations/honeycomb.hpp
+++ b/src/NSL/Lattice/Implementations/honeycomb.hpp
@@ -16,37 +16,40 @@ class Honeycomb: public NSL::Lattice::SpatialLattice<Type> {
          *
          **/
         explicit Honeycomb(
-                const std::vector<std::size_t L,
-                const Type &kappas = 1.);
+                const std::vector<int> L,
+                const Type &kappa = 1.);
+
+        const NSL::Tensor<int> L = NSL::Tensor<int>(2);
+        const int unit_cells;
 
     protected:
         //! Coordinate space lattice vectors
-        NSL::Tensor<double> a = {
-            {1.5, +0.8660254037844386}, // √(3) / 2 {√3, +1}
-            {1.5, -0.8660254037844386}  // √(3) / 2 {√3, -1}
-        };
+        //  √(3) / 2 {
+        //      {√3, +1}
+        //      {√3, -1}
+        //      }
+        NSL::Tensor<double> a = NSL::Tensor<double>(2,2);
+        
         // Separation between sites in the unit cell.
-        NSL::Tensor<double> r = {
-            1., 0.
-        };
+        // {1., 0.}
+        NSL::Tensor<double> r = NSL::Tensor<double>(2);
+        
         //! Reciprocal space lattice vectors
-        NSL::Tensor<double> b = {
-            {2.094395102393195, 3.627598728468436}, // 2π/√3 {1/√3, +1}
-            {2.094395102393195, -3.627598728468436} // 2π/√3 {1/√3, -1}
-        };
-
-        std::vector<std::size_t> L;
-        std::size_t unit_cells;
+        //  2π/√3 {
+        //      {1/√3, +1}
+        //      {1/√3, -1}
+        //      }
+        NSL::Tensor<double> b = NSL::Tensor<double>(2,2);
 
         Type kappa;
 
     private:
-        static inline double distance_squared(const NSL::Tensor<double> &x, const NSL::Tensor<double> &y);
-        static inline std::size_t unit_cells_(const std::vector<std::size_t> &L);
-        static inline std::size_t n_to_sites_(const std::vector<std::size_t> &n);
-        void init_(const std::vector<std::size_t> &n,
-                   const std::vector<Type> &kappa,
-                   const std::vector<double> spacings);
+        double distance_squared(const NSL::Tensor<double> &x, const NSL::Tensor<double> &y);
+        inline int unit_cells_(const std::vector<int> &L);
+        inline int L_to_sites_(const std::vector<int> &L);
+        void init_();
 };
+
+} // namespace NSL::Lattice
 
 #endif // NSL_LATTICE_HONEYCOMB_HPP

--- a/src/NSL/Lattice/Implementations/honeycomb.hpp
+++ b/src/NSL/Lattice/Implementations/honeycomb.hpp
@@ -38,15 +38,12 @@ class Honeycomb: public NSL::Lattice::SpatialLattice<Type> {
         std::vector<std::size_t> L;
         std::size_t unit_cells;
 
-        //! Coordinates
-        NSL::Tensor<Type> coordinates_;
         Type kappa;
 
     private:
         static inline double distance_squared(const NSL::Tensor<double> &x, const NSL::Tensor<double> &y);
         static inline std::size_t unit_cells_(const std::vector<std::size_t> &L);
         static inline std::size_t n_to_sites_(const std::vector<std::size_t> &n);
-        static NSL::Tensor<int> integer_coordinates_(const std::vector<std::size_t> &n);
         void init_(const std::vector<std::size_t> &n,
                    const std::vector<Type> &kappa,
                    const std::vector<double> spacings);

--- a/src/NSL/Lattice/Implementations/honeycomb.hpp
+++ b/src/NSL/Lattice/Implementations/honeycomb.hpp
@@ -1,0 +1,55 @@
+#ifndef NSL_LATTICE_HONEYCOMB_HPP
+#define NSL_LATTICE_HONEYCOMB_HPP
+
+#include "../lattice.hpp"
+
+namespace NSL::Lattice {
+
+/*! The honeycomb lattice of graphene.
+ **/
+template <typename Type>
+class Honeycomb: public NSL::Lattice::SpatialLattice<Type> {
+    public:
+        /*!
+         *  \param L the number of sites in the a1 and a2 directions
+         *  \param kappas the hopping parameter in each direction
+         *
+         **/
+        explicit Honeycomb(
+                const std::vector<std::size_t L,
+                const Type &kappas = 1.);
+
+    protected:
+        //! Coordinate space lattice vectors
+        NSL::Tensor<double> a = {
+            {1.5, +0.8660254037844386}, // √(3) / 2 {√3, +1}
+            {1.5, -0.8660254037844386}  // √(3) / 2 {√3, -1}
+        };
+        // Separation between sites in the unit cell.
+        NSL::Tensor<double> r = {
+            1., 0.
+        };
+        //! Reciprocal space lattice vectors
+        NSL::Tensor<double> b = {
+            {2.094395102393195, 3.627598728468436}, // 2π/√3 {1/√3, +1}
+            {2.094395102393195, -3.627598728468436} // 2π/√3 {1/√3, -1}
+        };
+
+        std::vector<std::size_t> L;
+        std::size_t unit_cells;
+
+        //! Coordinates
+        NSL::Tensor<Type> coordinates_;
+        Type kappa;
+
+    private:
+        static inline double distance_squared(const NSL::Tensor<double> &x, const NSL::Tensor<double> &y);
+        static inline std::size_t unit_cells_(const std::vector<std::size_t> &L);
+        static inline std::size_t n_to_sites_(const std::vector<std::size_t> &n);
+        static NSL::Tensor<int> integer_coordinates_(const std::vector<std::size_t> &n);
+        void init_(const std::vector<std::size_t> &n,
+                   const std::vector<Type> &kappa,
+                   const std::vector<double> spacings);
+};
+
+#endif // NSL_LATTICE_HONEYCOMB_HPP

--- a/src/NSL/Lattice/Implementations/honeycomb.tpp
+++ b/src/NSL/Lattice/Implementations/honeycomb.tpp
@@ -4,8 +4,8 @@
 
 /*! \file honeycomb.tpp
  *  \author Evan Berkowitz
- *  \date April 2023
- *  \brief Implementation of the honeycomb lattice for graphene.
+ *  \date   April 2023
+ *  \brief  Implementation of the honeycomb lattice for graphene.
 */
 
 #include <cmath>
@@ -13,45 +13,41 @@
 #include "honeycomb.hpp"
 
 // We describe the honeycomb lattice by a pair of integers L1, and L2,
+// which we group into a single std::vector<int>.
 namespace {
-    std::string name(const std::vector<std::size_t> &L){
+    std::string nameHoneycomb(const std::vector<int> &L){
         std::string result="Honeycomb(" + std::to_string(L[0]) +", " + std::to_string(L[1]) + ")";
         return result;
     }
+
+    NSL::Tensor<int> honeycomb_L_converter(const std::vector<int> &L){
+        NSL::Tensor<int> l(2);
+        l(0) = L[0];
+        l(1) = L[1];
+        return l;
+    }
 }
-// which we group into
-// a single std::vector<std::size_t> of length 2.  L1 and L2 multiply the lattice vectors
-//
-//  a1 = √(3) / 2 * [√3, +1]
-//  a2 = √(3) / 2 * [√3, -1]
-//
-// which has reciprocal vectors
-//
-// b1 = 2π/√3 * [1/√3, +1]
-// b2 = 2π/√3 * [1/√3, -1]
-//
-// so that ai.bj = 2π δ(i,j)
+
 namespace NSL::Lattice {
 
 // There are L1 * L2 unit cells,
 template<typename Type>
-inline std::size_t NSL::Lattice::Honeycomb<Type>::unit_cells_(const std::vector<std::size_t> &L){
-    std::size_t volume=1;
-    for(const auto& value: L) volume *= value;
+inline int NSL::Lattice::Honeycomb<Type>::unit_cells_(const std::vector<int> &L){
+    int volume=L[0] * L[1];
     return volume;
 }
 // and two sites per unit cell.
 template<typename Type>
-inline std::size_t NSL::Lattice::Honeycomb<Type>::L_to_sites_(const std::vector<std::size_t> &L){
+inline int NSL::Lattice::Honeycomb<Type>::L_to_sites_(const std::vector<int> &L){
     return 2*unit_cells_(L);
 }
 
 // Because we use periodic boundary conditions, the distance calculation is nontrivial,
 template<typename Type>
-double NSL::Lattice::Honeycomb<Type>::distance_squared(const NSL::Tensor<double> &x, const NSL::Tensor<double> &y){
+double Honeycomb<Type>::distance_squared(const NSL::Tensor<double> &x, const NSL::Tensor<double> &y){
 
-    NSL::Tensor<double> L1 = self->L[0] * self->a[0];
-    NSL::Tensor<double> L2 = self->L[1] * self->a[1];
+    NSL::Tensor<double> L1 = this->L(0) * this->a(0, NSL::Slice());
+    NSL::Tensor<double> L2 = this->L(1) * this->a(1, NSL::Slice());
 
     // The farthest things can be (with periodic boundary conditions) is much less than
     NSL::Tensor<double> vector = L1+L2;
@@ -63,9 +59,9 @@ double NSL::Lattice::Honeycomb<Type>::distance_squared(const NSL::Tensor<double>
     // cross the boundary.
     for(int sign1 = -1; sign1 <= 1; sign1++){
         for(int sign2 = -1; sign2 <= 1; sign2++){
-            vector = x-y+sign1*L1 + sign2*L2;
-            distance = NSL::LinLAlg::inner_product(vector, vector);
-            min = (min < distance) ? min : distance;
+            vector   = x - y + sign1*L1 + sign2*L2;
+            distance = NSL::LinAlg::inner_product(vector, vector);
+            min      = (min < distance) ? min : distance;
         }
     }
     return min;
@@ -73,19 +69,27 @@ double NSL::Lattice::Honeycomb<Type>::distance_squared(const NSL::Tensor<double>
 
 
 template<typename Type>
-void NSL::Lattice::Honeycomb<Type>::init_(const std::vector<std::size_t> &L,
-                   const Type &kappa)
+void NSL::Lattice::Honeycomb<Type>::init_()
 {
+    this->a(0,0) = +1.5;                    // +3/2
+    this->a(0,1) = +0.8660254037844386;     // +√(3)/2
+    this->a(1,0) = +1.5;                    // +3/2
+    this->a(1,1) = -0.8660254037844386;     // -√(3)/2
 
-    this->kappa = kappa;
-    this->spacings_ = spacings;
+    this->r(0) = 1.;
+    this->r(1) = 0.;
+    
+    this->b(0,0) = +2.094395102393195;      // +2π/3
+    this->b(0,1) = +3.627598728468436;      // +2π/√3
+    this->b(1,0) = +2.094395102393195;      // +2π/3
+    this->b(1,1) = -3.627598728468436;      // -2π/√3
 
-    for(int L1 = 0; L1 < L[0]; ++L1){
-        for(int L2 = 0; L2 < L[1]; ++L2){
-            i = L1 + L[0]*L2;
+    for(int L1 = 0; L1 < this->L(0); ++L1){
+        for(int L2 = 0; L2 < this->L(1); ++L2){
+            int i = L1 + this->L(0)*L2;
             // Now alternate over the A/B structure
-            this->sites_(2*i+0) = NSL::LinAlg::mat_mul(L, this->a) + this->r/2;
-            this->sites_(2*i+1) = NSL::LinAlg::mat_mul(L, this->a) - this->r/2;
+            this->sites_(2*i+0, NSL::Slice()) = L1 * a(0, NSL::Slice()) + L2 * a(1, NSL::Slice()) + this->r/2;
+            this->sites_(2*i+1, NSL::Slice()) = L1 * a(0, NSL::Slice()) + L2 * a(1, NSL::Slice()) - this->r/2;
         }
     }
 
@@ -94,12 +98,12 @@ void NSL::Lattice::Honeycomb<Type>::init_(const std::vector<std::size_t> &L,
     // But, it works for now.
     for (int i = 0; i < this->sites(); ++i){
         for (int j = i; j < this->sites(); ++j){
-            double distance_squared = this->distance_squared(sites_(i) - sites_(j))
+            double distance_squared = this->distance_squared(this->sites_(i, NSL::Slice()), this->sites_(j, NSL::Slice()));
 
             // Typically for 0ness we would check a small cutoff like
             // 1e-12.  But we already know, by the geometry and correctness
             // of the coordinates, that this is 'close enough'.
-            if( (distance_squared-1).abs() < 0.01){
+            if( NSL::LinAlg::abs(distance_squared-1) < 0.0001){
                 this->hops_(i,j) = kappa;
                 this->hops_(j,i) = kappa;
                 }
@@ -116,18 +120,20 @@ void NSL::Lattice::Honeycomb<Type>::init_(const std::vector<std::size_t> &L,
 
 template<typename Type>
 NSL::Lattice::Honeycomb<Type>::Honeycomb(
-            const std::vector<std::size_t> L,
+            const std::vector<int> L,
             const Type & kappa
             ):
         NSL::Lattice::SpatialLattice<Type>(
-                name(L),
-                NSL::Tensor<Type>(this->n_to_sites_(n), this->n_to_sites_(n)),
-                NSL::Tensor<double>(this->n_to_sites_(n), 2)
+                nameHoneycomb(L),
+                NSL::Tensor<Type>(this->L_to_sites_(L), this->L_to_sites_(L)),
+                NSL::Tensor<double>(this->L_to_sites_(L), 2)
         ),
-        L(L),
-        unit_cells(this->unit_cells_(L))
+        unit_cells(this->unit_cells_(L)),
+        L(honeycomb_L_converter(L)), //! todo This is a dirty hack some day we should have constructor std::vector -> NSL::Tensor 
+        kappa(kappa)
 {
-    this->init_(L, kappa);
+
+    this->init_();
 }
 
 } // namespace NSL::Lattice

--- a/src/NSL/Lattice/Implementations/honeycomb.tpp
+++ b/src/NSL/Lattice/Implementations/honeycomb.tpp
@@ -51,7 +51,7 @@ template<typename Type>
 double NSL::Lattice::Honeycomb<Type>::distance_squared(const NSL::Tensor<double> &x, const NSL::Tensor<double> &y){
 
     NSL::Tensor<double> L1 = self->L[0] * self->a[0];
-    NSL::Tensor<double> L2 = self->L[0] * self->a[0];
+    NSL::Tensor<double> L2 = self->L[1] * self->a[1];
 
     // The farthest things can be (with periodic boundary conditions) is much less than
     NSL::Tensor<double> vector = L1+L2;
@@ -84,8 +84,8 @@ void NSL::Lattice::Honeycomb<Type>::init_(const std::vector<std::size_t> &L,
         for(int L2 = 0; L2 < L[1]; ++L2){
             i = L1 + L[0]*L2;
             // Now alternate over the A/B structure
-            this->sites_(2*i+0) = NSL::LinAlg::mat_mul(this->a, L) + this->r/2;
-            this->sites_(2*i+1) = NSL::LinAlg::mat_mul(this->a, L) - this->r/2;
+            this->sites_(2*i+0) = NSL::LinAlg::mat_mul(L, this->a) + this->r/2;
+            this->sites_(2*i+1) = NSL::LinAlg::mat_mul(L, this->a) - this->r/2;
         }
     }
 

--- a/src/NSL/Lattice/Implementations/honeycomb.tpp
+++ b/src/NSL/Lattice/Implementations/honeycomb.tpp
@@ -1,0 +1,134 @@
+#ifndef NSL_LATTICE_HONEYCOMB_TPP
+#define NSL_LATTICE_HONEYCOMB_TPP
+
+
+/*! \file honeycomb.tpp
+ *  \author Evan Berkowitz
+ *  \date April 2023
+ *  \brief Implementation of the honeycomb lattice for graphene.
+*/
+
+#include <cmath>
+
+#include "honeycomb.hpp"
+
+// We describe the honeycomb lattice by a pair of integers L1, and L2,
+namespace {
+    std::string name(const std::vector<std::size_t> &L){
+        std::string result="Honeycomb(" + std::to_string(L[0]) +", " + std::to_string(L[1]) + ")";
+        return result;
+    }
+}
+// which we group into
+// a single std::vector<std::size_t> of length 2.  L1 and L2 multiply the lattice vectors
+//
+//  a1 = √(3) / 2 * [√3, +1]
+//  a2 = √(3) / 2 * [√3, -1]
+//
+// which has reciprocal vectors
+//
+// b1 = 2π/√3 * [1/√3, +1]
+// b2 = 2π/√3 * [1/√3, -1]
+//
+// so that ai.bj = 2π δ(i,j)
+namespace NSL::Lattice {
+
+// There are L1 * L2 unit cells,
+template<typename Type>
+inline std::size_t NSL::Lattice::Honeycomb<Type>::unit_cells_(const std::vector<std::size_t> &L){
+    std::size_t volume=1;
+    for(const auto& value: L) volume *= value;
+    return volume;
+}
+// and two sites per unit cell.
+template<typename Type>
+inline std::size_t NSL::Lattice::Honeycomb<Type>::L_to_sites_(const std::vector<std::size_t> &L){
+    return 2*unit_cells_(L);
+}
+
+// Because we use periodic boundary conditions, the distance calculation is nontrivial,
+template<typename Type>
+double NSL::Lattice::Honeycomb<Type>::distance_squared(const NSL::Tensor<double> &x, const NSL::Tensor<double> &y){
+
+    NSL::Tensor<double> L1 = self->L[0] * self->a[0];
+    NSL::Tensor<double> L2 = self->L[0] * self->a[0];
+
+    // The farthest things can be (with periodic boundary conditions) is much less than
+    NSL::Tensor<double> vector = L1+L2;
+    double distance = NSL::LinAlg::inner_product(vector, vector);
+    double min = distance;
+
+    // Now we check all possibilities of having to go across the boundary.
+    // 'sign' is maybe a bit funny for a name, it can be 0 too, if you don't
+    // cross the boundary.
+    for(int sign1 = -1; sign1 <= 1; sign1++){
+        for(int sign2 = -1; sign2 <= 1; sign2++){
+            vector = x-y+sign1*L1 + sign2*L2;
+            distance = NSL::LinLAlg::inner_product(vector, vector);
+            min = (min < distance) ? min : distance;
+        }
+    }
+    return min;
+}
+
+
+template<typename Type>
+void NSL::Lattice::Honeycomb<Type>::init_(const std::vector<std::size_t> &L,
+                   const Type &kappa)
+{
+
+    this->kappa = kappa;
+    this->spacings_ = spacings;
+
+    for(int L1 = 0; L1 < L[0]; ++L1){
+        for(int L2 = 0; L2 < L[1]; ++L2){
+            i = L1 + L[0]*L2;
+            // Now alternate over the A/B structure
+            this->sites_(2*i+0) = NSL::LinAlg::mat_mul(this->a, L) + this->r/2;
+            this->sites_(2*i+1) = NSL::LinAlg::mat_mul(this->a, L) - this->r/2;
+        }
+    }
+
+    //! todo this algorithm is quadratic in the number of sites.
+    // I think, with intelligence, it can be made linear.
+    // But, it works for now.
+    for (int i = 0; i < this->sites(); ++i){
+        for (int j = i; j < this->sites(); ++j){
+            double distance_squared = this->distance_squared(sites_(i) - sites_(j))
+
+            // Typically for 0ness we would check a small cutoff like
+            // 1e-12.  But we already know, by the geometry and correctness
+            // of the coordinates, that this is 'close enough'.
+            if( (distance_squared-1).abs() < 0.01){
+                this->hops_(i,j) = kappa;
+                this->hops_(j,i) = kappa;
+                }
+        }
+    }
+
+    this->compute_adjacency();
+
+}
+
+//=====================================================================
+// Constructors
+//=====================================================================
+
+template<typename Type>
+NSL::Lattice::Honeycomb<Type>::Honeycomb(
+            const std::vector<std::size_t> L,
+            const Type & kappa
+            ):
+        NSL::Lattice::SpatialLattice<Type>(
+                name(L),
+                NSL::Tensor<Type>(this->n_to_sites_(n), this->n_to_sites_(n)),
+                NSL::Tensor<double>(this->n_to_sites_(n), 2)
+        ),
+        L(L),
+        unit_cells(this->unit_cells_(L))
+{
+    this->init_(L, kappa);
+}
+
+} // namespace NSL::Lattice
+#endif //NSL_LATTICE_HONEYCOMB_TPP


### PR DESCRIPTION
This provides an `NSL::Lattice::Honeycomb` class, which is constructed from an `std::vector<int> L` of length 2, and an optional kappa (default = 1).

It has been checked as follows:
 - test_honeycomb checks the number of sites is twice the number of unit cells.
 - test_honeycomb checks that the valence of every vertex is 3.
 - test_honeycomb checks that the hopping matrix is Hermitian.
 - example_honeycomb spits out the hopping matrix for a (3,3) lattice and it matches the spectrum of my Mathematica implementation.  I've done the same check for (2,2) and (2,3) with success but beyond that my testing procedure is manual and annoying.  It will be much simpler to automate a bit when this stuff has access to the HDF5 capabilities.

To me these suggest correctness.

Something that would be nice to have is a check of the eigenvalues in test_honeycomb.  For example, all the eigenvalues should be between -3 and 3, there should only be Dirac points if (L1, L2) == (0,0) [mod 3], and so on.  But this needs to wait to coexist with some eigenvalue infrastructure.  If this is merged we should open that as an issue.