### PR TITLE
Added OpenMP parallelization

### DIFF
--- a/src/NSL/commandLineInterface.hpp
+++ b/src/NSL/commandLineInterface.hpp
@@ -98,6 +98,10 @@ NSL::Parameter init(int argc, char ** argv, std::string CLIName = "NSL"){
         "Using device: {}", std::string(params["device"])
     );
 
+    // This initializes all possible OpenMP/KNL threads
+    // Notice this requires torch 
+    at::init_num_threads();
+
     return params;
 }
 


### PR DESCRIPTION
 This function is called during the python setup of Pytorch but not on the C++ site. We need this to enable OpenMP.

https://github.com/pytorch/pytorch/issues/20156 