### PR TITLE
Feature/two body correlators

### DIFF
--- a/Executables/Examples/CMakeLists.txt
+++ b/Executables/Examples/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_executable(example_k_correlators example_k_correlators.cpp)
+target_link_libraries(example_k_correlators NSL)
 
 add_executable(example_TensorBasics example_tensor_basics.cpp)
 target_link_libraries(example_TensorBasics NSL)

--- a/Executables/Examples/CMakeLists.txt
+++ b/Executables/Examples/CMakeLists.txt
@@ -1,3 +1,6 @@
+add_executable(example_2_correlators example_2_correlators.cpp)
+target_link_libraries(example_2_correlators NSL)
+
 add_executable(example_k_correlators example_k_correlators.cpp)
 target_link_libraries(example_k_correlators NSL)
 

--- a/Executables/Examples/example_2_correlators.cpp
+++ b/Executables/Examples/example_2_correlators.cpp
@@ -131,20 +131,26 @@ int main(int argc, char** argv){
     // Put the lattice on the device. (copy to GPU)
     lattice.to(params["device"]);
 
-    // initialize 2 point correlation function <p^+_x p_y> 
+    // Initialize 2 point correlation function
     NSL::Measure::Hubbard::TwoBodyCorrelator<
         Type,
         decltype(lattice),
         NSL::FermionMatrix::HubbardExp<
             Type,decltype(lattice)
         >
-    > C2pt_sp(lattice, params, h5);//, NSL::Hubbard::Particle, NSL::Hubbard::Particle);
+    > C2pt_2b(lattice, params, h5);
 
     // Perform the measurement.
-    // 1. Calculate <p^+_x p_y> = \sum_{ts} < M^{-1}_{t-t_s,x;0;y } >
+    // 1. Calculate all:
+    // <p^+_x p_y> = \sum_{ts} < M^{-1}_{t-t_s,x;0;y }[\phi] >
+    // <p_x p^+_y> = \sum_{ts} < M^{-1}^+_{t-t_s,x;0;y }[-\phi] >
+    // <h^+_x h_y> = \sum_{ts} < M^{-1}_{t-t_s,x;0;y }[\phi] >
+    // <h_x h^+_y> = \sum_{ts} < M^{-1}^+_{t-t_s,x;0;y }[-\phi] >
+    // 
+    // 2. Create the two-body correlation functions
     //
-    // configurations from the data file specified under params["file"].
+    // Configurations from the data file specified under params["file"].
     // Then 
-    C2pt_sp.measure();
+    C2pt_2b.measure();
 
 }

--- a/Executables/Examples/example_2_correlators.cpp
+++ b/Executables/Examples/example_2_correlators.cpp
@@ -116,11 +116,11 @@ int main(int argc, char** argv){
     //    exit(0);
     
     // create an H5 object to store data
-    NSL::H5IO h5(params["h5file"], params["overwrite"]);
-    // NSL::H5IO h5(
-    // params["h5file"], 
-    // bool (params["overwrite"]) ? NSL::File::Truncate : NSL::File::ReadWrite | NSL::File::OpenOrCreate
-    // );
+    // NSL::H5IO h5(params["h5file"], params["overwrite"]);
+    NSL::H5IO h5(
+    params["h5file"], 
+    bool (params["overwrite"]) ? NSL::File::Truncate : NSL::File::ReadWrite | NSL::File::OpenOrCreate
+    );
 
     // define the basenode for the h5file, everything is stored in 
     // params["h5Filename"]/BASENODE/

--- a/Executables/Examples/example_2_correlators.cpp
+++ b/Executables/Examples/example_2_correlators.cpp
@@ -1,0 +1,140 @@
+#include "NSL.hpp"
+
+int main(int argc, char** argv){
+    typedef NSL::complex<double> Type;
+
+    NSL::Parameter params = NSL::init(argc,argv,"NSL Hubbard Correlator");
+    
+    // Now all parameters are stored in yml, we want to translate them 
+    // into the parameter object
+    // We can read in the parameter file and put the read data into the 
+    // params object, notice this uses the example_param.yml file
+    // For personal files, this code needs to be adjusted accordingly
+    YAML::Node yml = YAML::LoadFile(params["file"]);
+
+    // convert the data from example_param.yml and put it into the params
+    // The name of the physical system
+    params["name"]              = yml["system"]["name"].as<std::string>();
+    // The inverse temperature 
+    params["beta"]              = yml["system"]["beta"].as<double>();
+    // The number of time slices
+    params["Nt"]                = yml["system"]["Nt"].as<NSL::size_t>();
+    // The number of ions
+    params["Nx"]                = yml["system"]["nions"].as<NSL::size_t>();
+    // The on-site interaction
+    params["U"]                 = yml["system"]["U"].as<double>();
+    // The HMC save frequency
+    params["save frequency"]    = yml["HMC"]["save frequency"].as<NSL::size_t>();
+    // The thermalization length
+    params["Ntherm"]            = yml["HMC"]["Ntherm"].as<NSL::size_t>();
+    // The number of configurations
+    params["Nconf"]             = yml["HMC"]["Nconf"].as<NSL::size_t>();
+    // The trajectory length
+    params["trajectory length"] = yml["Leapfrog"]["trajectory length"].as<double>();
+    // The number of molecular dynamic steps
+    params["Nmd"]               = yml["Leapfrog"]["Nmd"].as<NSL::size_t>();
+    // The h5 file name to store the simulation results
+    params["h5file"]            = yml["fileIO"]["h5file"].as<std::string>();
+    // The offset: tangent plane/NLO plane
+    if (yml["system"]["offset"]){
+        params["offset"]        = yml["system"]["offset"].as<double>();
+    } else {
+        // DEFAULT: offset = 0
+        params["offset"]        = 0.0;
+    }
+    // Chemical Potential
+    if (yml["system"]["mu"]){
+        params["mu"]            = yml["system"]["mu"].as<double>();
+    } else {
+        // DEFAULT: mu = 0
+        params["mu"]            = 0.0;
+    }
+    // Number of Sources for the cg
+    if (yml["measurements"]["Number Time Sources"]){
+        params["Number Time Sources"] = yml["measurements"]["Number Time Sources"].as<NSL::size_t>();
+    } else {
+        // DEFAULT: Number Time Sources = Nt
+        params["Number Time Sources"] = params["Nt"];
+    }
+
+    // Now we want to log the found parameters
+    // - key is a std::string name,beta,...
+    // - value is a ParameterEntry * which is a wrapper around the actual 
+    //   value of interest, we can use ParameterEntry::repr() to get a string
+    //   representation of the stored value
+    for(auto [key, value]: params){
+        // skip these keys as they are logged in init already
+        if (key == "device" || key == "file") {continue;}
+        NSL::Logger::info( "{}: {}", key, value );
+    }
+
+    std::vector<std::vector<std::vector<std::vector<double>>>> kblocks2d;
+    std::vector<std::vector<double>> momenta;
+   
+
+    // Load momentum blocks if they exist
+    if (yml["measurements"]["momenta"]){
+      momenta = yml["measurements"]["momenta"].as<std::vector<std::vector<double>>>();
+      NSL::Tensor<double> mblocks(momenta.size(),momenta[0].size());
+      for (int i=0;i<momenta.size(); i++){
+	for (int j=0;j<momenta[0].size();j++){
+	  mblocks(i,j) = momenta[i][j];
+	}
+      }
+      params["momenta"]=mblocks;
+    }
+    if (yml["measurements"]["wallSources"]){
+      kblocks2d = yml["measurements"]["wallSources"].as<std::vector<std::vector<std::vector<std::vector<double>>>>>();
+      NSL::Tensor<NSL::complex<double>> kblocks(kblocks2d.size(),kblocks2d[0].size(),kblocks2d[0][0].size());
+      NSL::Logger::info( "Measuring {} momentum block(s), each with {} band(s) of length {}",kblocks2d.size(),kblocks2d[0].size(),kblocks2d[0][0].size());
+
+      // now populate the momentum blocks with proper complex variables
+      for (int i=0; i<kblocks2d.size(); i++){
+        for (int j=0; j<kblocks2d[0].size(); j++) {
+          for (int k=0; k<kblocks2d[0][0].size(); k++) {
+            kblocks(i,j,k) = NSL::complex<double> (kblocks2d[i][j][k][0], kblocks2d[i][j][k][1]);
+          }
+        }
+      }
+      params["wallSources"]=kblocks;
+    } else {
+      // DEFAULT: raise an exception
+      // currently don't know how to do this, will do later
+    }
+
+    
+    //    exit(0);
+    
+    // create an H5 object to store data
+    NSL::H5IO h5(params["h5file"], params["overwrite"]);
+    // NSL::H5IO h5(
+    // params["h5file"], 
+    // bool (params["overwrite"]) ? NSL::File::Truncate : NSL::File::ReadWrite | NSL::File::OpenOrCreate
+    // );
+
+    // define the basenode for the h5file, everything is stored in 
+    // params["h5Filename"]/BASENODE/
+    std::string BASENODE(fmt::format("{}",std::string(params["name"])));
+    // initialize the lattice 
+    NSL::Lattice::Generic<Type> lattice(yml);
+
+    // Put the lattice on the device. (copy to GPU)
+    lattice.to(params["device"]);
+
+    // initialize 2 point correlation function <p^+_x p_y> 
+    NSL::Measure::Hubbard::TwoBodyCorrelator<
+        Type,
+        decltype(lattice),
+        NSL::FermionMatrix::HubbardExp<
+            Type,decltype(lattice)
+        >
+    > C2pt_sp(lattice, params, h5);//, NSL::Hubbard::Particle, NSL::Hubbard::Particle);
+
+    // Perform the measurement.
+    // 1. Calculate <p^+_x p_y> = \sum_{ts} < M^{-1}_{t-t_s,x;0;y } >
+    //
+    // configurations from the data file specified under params["file"].
+    // Then 
+    C2pt_sp.measure();
+
+}

--- a/Executables/Examples/example_2_correlators.cpp
+++ b/Executables/Examples/example_2_correlators.cpp
@@ -77,12 +77,22 @@ int main(int argc, char** argv){
       momenta = yml["measurements"]["momenta"].as<std::vector<std::vector<double>>>();
       NSL::Tensor<double> mblocks(momenta.size(),momenta[0].size());
       for (int i=0;i<momenta.size(); i++){
-	for (int j=0;j<momenta[0].size();j++){
-	  mblocks(i,j) = momenta[i][j];
-	}
+        for (int j=0;j<momenta[0].size();j++){
+          mblocks(i,j) = momenta[i][j];
+        }
       }
       params["momenta"]=mblocks;
     }
+    // if (yml["measurements"]["momenta"]){
+    //   momenta = yml["measurements"]["momenta"].as<std::vector<std::vector<double>>>();
+    //   NSL::Tensor<double> mblocks(momenta.size(),momenta[0].size());
+    //   for (int i=0;i<momenta.size(); i++){
+    //     for (int j=0;j<momenta[0].size();j++){
+    //       mblocks(i,j) = momenta[i][j];
+    //     }
+    //   }
+    //   params["momenta"]=momenta;
+    // }
     if (yml["measurements"]["wallSources"]){
       kblocks2d = yml["measurements"]["wallSources"].as<std::vector<std::vector<std::vector<std::vector<double>>>>>();
       NSL::Tensor<NSL::complex<double>> kblocks(kblocks2d.size(),kblocks2d[0].size(),kblocks2d[0][0].size());

--- a/Executables/Examples/example_2_correlators.cpp
+++ b/Executables/Examples/example_2_correlators.cpp
@@ -106,7 +106,7 @@ int main(int argc, char** argv){
           }
         }
       }
-      params["wallSources"]=kblocks;
+      params["wallSources"]=kblocks.to(params["device"]);
     } else {
       // DEFAULT: raise an exception
       // currently don't know how to do this, will do later

--- a/Executables/Examples/example_k_correlators.cpp
+++ b/Executables/Examples/example_k_correlators.cpp
@@ -106,7 +106,10 @@ int main(int argc, char** argv){
     //    exit(0);
     
     // create an H5 object to store data
-    NSL::H5IO h5(params["h5file"], params["overwrite"]);
+    NSL::H5IO h5(
+        params["h5file"].to<std::string>(), 
+        params["overwrite"].to<bool>() ? NSL::File::Truncate : NSL::File::ReadWrite | NSL::File::OpenOrCreate
+    );
 
     // define the basenode for the h5file, everything is stored in 
     // params["h5Filename"]/BASENODE/

--- a/Executables/Examples/example_k_correlators.cpp
+++ b/Executables/Examples/example_k_correlators.cpp
@@ -1,0 +1,125 @@
+#include "NSL.hpp"
+
+int main(int argc, char** argv){
+    typedef NSL::complex<double> Type;
+
+    NSL::Parameter params = NSL::init(argc,argv,"NSL Hubbard Correlator");
+    
+    // Now all parameters are stored in yml, we want to translate them 
+    // into the parameter object
+    // We can read in the parameter file and put the read data into the 
+    // params object, notice this uses the example_param.yml file
+    // For personal files, this code needs to be adjusted accordingly
+    YAML::Node yml = YAML::LoadFile(params["file"]);
+
+    // convert the data from example_param.yml and put it into the params
+    // The name of the physical system
+    params["name"]              = yml["system"]["name"].as<std::string>();
+    // The inverse temperature 
+    params["beta"]              = yml["system"]["beta"].as<double>();
+    // The number of time slices
+    params["Nt"]                = yml["system"]["Nt"].as<NSL::size_t>();
+    // The number of ions
+    params["Nx"]                = yml["system"]["nions"].as<NSL::size_t>();
+    // The on-site interaction
+    params["U"]                 = yml["system"]["U"].as<double>();
+    // The HMC save frequency
+    params["save frequency"]    = yml["HMC"]["save frequency"].as<NSL::size_t>();
+    // The thermalization length
+    params["Ntherm"]            = yml["HMC"]["Ntherm"].as<NSL::size_t>();
+    // The number of configurations
+    params["Nconf"]             = yml["HMC"]["Nconf"].as<NSL::size_t>();
+    // The trajectory length
+    params["trajectory length"] = yml["Leapfrog"]["trajectory length"].as<double>();
+    // The number of molecular dynamic steps
+    params["Nmd"]               = yml["Leapfrog"]["Nmd"].as<NSL::size_t>();
+    // The h5 file name to store the simulation results
+    params["h5file"]            = yml["fileIO"]["h5file"].as<std::string>();
+    // The offset: tangent plane/NLO plane
+    if (yml["system"]["offset"]){
+        params["offset"]        = yml["system"]["offset"].as<double>();
+    } else {
+        // DEFAULT: offset = 0
+        params["offset"]        = 0.0;
+    }
+    // Chemical Potential
+    if (yml["system"]["mu"]){
+        params["mu"]            = yml["system"]["mu"].as<double>();
+    } else {
+        // DEFAULT: mu = 0
+        params["mu"]            = 0.0;
+    }
+    // Number of Sources for the cg
+    if (yml["measurements"]["Number Time Sources"]){
+        params["Number Time Sources"] = yml["measurements"]["Number Time Sources"].as<NSL::size_t>();
+    } else {
+        // DEFAULT: Number Time Sources = Nt
+        params["Number Time Sources"] = params["Nt"];
+    }
+
+    // Load momentum blocks if they exist
+    if (yml["measurements"]["momenta"]){
+      params["wallSources"] = yml["measurements"]["momenta"].as<std::vector<std::vector<std::vector<std::vector<double>>>>>();
+    } else {
+      // DEFAULT: raise an exception
+      // currently don't know how to do this, will do later
+    }
+
+    // Now we want to log the found parameters
+    // - key is a std::string name,beta,...
+    // - value is a ParameterEntry * which is a wrapper around the actual 
+    //   value of interest, we can use ParameterEntry::repr() to get a string
+    //   representation of the stored value
+    for(auto [key, value]: params){
+        // skip these keys as they are logged in init already
+        if (key == "device" || key == "file") {continue;}
+        NSL::Logger::info( "{}: {}", key, value );
+    }
+
+    // create an H5 object to store data
+    NSL::H5IO h5(params["h5file"], params["overwrite"]);
+
+    // define the basenode for the h5file, everything is stored in 
+    // params["h5Filename"]/BASENODE/
+    std::string BASENODE(fmt::format("{}",std::string(params["name"])));
+    // initialize the lattice 
+    NSL::Lattice::Generic<Type> lattice(yml);
+
+    // Put the lattice on the device. (copy to GPU)
+    lattice.to(params["device"]);
+
+
+    std::cout << params["wallSources"] << std::endl;
+    
+    // // initialize 2 point correlation function <p^+_x p_y> 
+    // NSL::Measure::Hubbard::TwoPointCorrelator<
+    //     Type,
+    //     decltype(lattice),
+    //     NSL::FermionMatrix::HubbardExp<
+    //         Type,decltype(lattice)
+    //     >
+    // > C2pt_sp(lattice, params, h5, NSL::Hubbard::Particle);
+
+    // // Perform the measurement.
+    // // 1. Calculate <p^+_x p_y> = \sum_{ts} < M^{-1}_{t-t_s,x;0;y } >
+    // //
+    // // configurations from the data file specified under params["file"].
+    // // Then 
+    // C2pt_sp.measure();
+
+    // // initialize 2 point correlation function <h^+_x h_y> 
+    // NSL::Measure::Hubbard::TwoPointCorrelator<
+    //     Type,
+    //     decltype(lattice),
+    //     NSL::FermionMatrix::HubbardExp<
+    //         Type,decltype(lattice)
+    //     >
+    // > C2pt_sh(lattice, params, h5, NSL::Hubbard::Hole);
+
+    // // Perform the measurement.
+    // // 1. Calculate <h^+_x h_y> = \sum_{ts} < M^{-1}_{t-t_s,x;0;y } >
+    // //
+    // // configurations from the data file specified under params["file"].
+    // // Then 
+    // C2pt_sh.measure();
+}

--- a/Executables/Examples/example_k_correlators.cpp
+++ b/Executables/Examples/example_k_correlators.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv){
 	  }
 	}
       }
-      params["wallSources"]=kblocks;
+      params["wallSources"]=kblocks.to(params["device"]);
     } else {
       // DEFAULT: raise an exception
       // currently don't know how to do this, will do later

--- a/Executables/Examples/example_tensor_basics.cpp
+++ b/Executables/Examples/example_tensor_basics.cpp
@@ -193,7 +193,19 @@ int main(){
                  
     std::cout << std::endl << "=================================" << std::endl << std::endl;
 
-    // 2. Elementwise operations like exponentiation
+    // 2. Tensor arithmetic like (elementwise) multiplication
+    NSL::Tensor<double> mat3(4,4); mat3.rand();
+    auto matProd = mat(0, NSL::Slice()) * mat3; // creates a new tensor with new memory
+
+    std::cout << "Multiplying another random matrix to `mat` results in: " << std::endl
+              << mat(0, NSL::Slice())
+              << mat3
+              << matProd
+              << std::endl;
+                 
+    std::cout << std::endl << "=================================" << std::endl << std::endl;
+
+    // 3. Elementwise operations like exponentiation
     auto matExp = NSL::LinAlg::exp(mat); // creates a new tensor with new memory
     mat.exp(); // uses the same memory space as mat
     

--- a/src/NSL/IO/h5_io.tpp
+++ b/src/NSL/IO/h5_io.tpp
@@ -416,7 +416,18 @@ class H5IO {
                 NSL::Logger::debug("Unlinking Dataset (overwrite={}; node exists={}): {}",overwrite_,exist,node);
                 h5f_.unlink(node);
             }
-        }  
+        } 
+
+        //! Removes a group if group exists
+        void trimData(std::string node){
+            bool exist = this->exist(node);
+            // remove the group if it exists; once the file is closed
+            // automatic repacking is applied
+            if (exist){
+                NSL::Logger::debug("Unlinking Dataset (node exists={}): {}",exist,node);
+                h5f_.unlink(node);
+            }
+        }
     private:
         
 

--- a/src/NSL/IO/h5_io.tpp
+++ b/src/NSL/IO/h5_io.tpp
@@ -74,7 +74,7 @@ class H5IO {
 	            baseNode = node + "/";// + std::to_string(markovstate.markovTime);
 	        }
 
-            this->removeData_(baseNode);
+            this->removeData(baseNode);
 
             // write out the configuration
     	    this -> write(markovstate.configuration, baseNode);
@@ -237,7 +237,7 @@ class H5IO {
 
             NSL::Tensor<Type> tensor = tensor_in.to(NSL::CPU()); 
 
-            this->removeData_(node);
+            this->removeData(node);
 
 	        if constexpr (NSL::is_complex<Type>()) {
                 std::vector<std::complex<NSL::RealTypeOf<Type>>> phi(
@@ -283,7 +283,7 @@ class H5IO {
 
         template <NSL::Concept::isNumber Type> 
         inline int write(const NSL::Configuration<Type> &config, const std::string node){
-            this->removeData_(node);
+            this->removeData(node);
 
 	        for (auto [key,field] : config) {
 	            if (node.back() == '/'){
@@ -406,10 +406,9 @@ class H5IO {
         inline bool overwrite(){
             return overwrite_;
         } // overwrite()
-          
-    private:
+        
         //! Removes a group if overwrite == True and group exists
-        void removeData_(std::string node){
+        void removeData(std::string node){
             bool exist = this->exist(node);
             // remove the group if it exists; once the file is closed
             // automatic repacking is applied
@@ -417,7 +416,9 @@ class H5IO {
                 NSL::Logger::debug("Unlinking Dataset (overwrite={}; node exists={}): {}",overwrite_,exist,node);
                 h5f_.unlink(node);
             }
-        }
+        }  
+    private:
+        
 
 
         std::string h5file_;

--- a/src/NSL/IO/h5_io.tpp
+++ b/src/NSL/IO/h5_io.tpp
@@ -215,10 +215,6 @@ class H5IO {
 	            dataset = h5f_.getDataSet(baseNode+"/acceptanceProbability");
 	            dataset.read(markovstate.acceptanceProbability);
 
-                // read in the acceptanceProbability
-	            dataset = h5f_.getDataSet(baseNode+"/acceptanceRate");
-	            dataset.read(markovstate.accepted);
-
 	            // read in the weights (eg logdetJ, etc. . .)
 	            for (auto & [key,field] : markovstate.weights) {
 	                dataset = h5f_.getDataSet(baseNode+"/weights/"+key);
@@ -235,10 +231,6 @@ class H5IO {
 	            // read in the acceptanceProbability
 	            dataset = h5f_.getDataSet(baseNode+"/acceptanceProbability");
 	            dataset.read(markovstate.acceptanceProbability);
-
-                // read in the acceptanceProbability
-	            dataset = h5f_.getDataSet(baseNode+"/acceptanceRate");
-	            dataset.read(markovstate.accepted);
 
 	            // read in the weights (eg logdetJ, etc. . .)
 	            for (auto & [key,field] : markovstate.weights) {

--- a/src/NSL/IO/h5_io.tpp
+++ b/src/NSL/IO/h5_io.tpp
@@ -74,8 +74,6 @@ class H5IO {
 	            baseNode = node + "/";// + std::to_string(markovstate.markovTime);
 	        }
 
-            this->removeData(baseNode);
-
             // write out the configuration
     	    this -> write(markovstate.configuration, baseNode);
 
@@ -252,8 +250,6 @@ class H5IO {
 
             NSL::Tensor<Type> tensor = tensor_in.to(NSL::CPU()); 
 
-            this->removeData(node);
-
 	        if constexpr (NSL::is_complex<Type>()) {
                 std::vector<std::complex<NSL::RealTypeOf<Type>>> phi(
                     tensor.data(), 
@@ -298,7 +294,6 @@ class H5IO {
 
         template <NSL::Concept::isNumber Type> 
         inline int write(const NSL::Configuration<Type> &config, const std::string node){
-            this->removeData(node);
 
 	        for (auto [key,field] : config) {
 	            if (node.back() == '/'){
@@ -421,20 +416,9 @@ class H5IO {
         inline bool overwrite(){
             return overwrite_;
         } // overwrite()
-        
-        //! Removes a group if overwrite == True and group exists
-        void removeData(std::string node){
-            bool exist = this->exist(node);
-            // remove the group if it exists; once the file is closed
-            // automatic repacking is applied
-            if (overwrite_ and exist){
-                NSL::Logger::debug("Unlinking Dataset (overwrite={}; node exists={}): {}",overwrite_,exist,node);
-                h5f_.unlink(node);
-            }
-        } 
 
-        //! Removes a group if group exists
-        void trimData(std::string node){
+        //! Deletes a group if group exists
+        void deleteData(std::string node){
             bool exist = this->exist(node);
             // remove the group if it exists; once the file is closed
             // automatic repacking is applied
@@ -445,8 +429,6 @@ class H5IO {
         }
     private:
         
-
-
         std::string h5file_;
         File h5f_;
         bool overwrite_;

--- a/src/NSL/IO/h5_io.tpp
+++ b/src/NSL/IO/h5_io.tpp
@@ -98,6 +98,14 @@ class H5IO {
 	            
                 dataset.write(markovstate.acceptanceProbability);
 
+                // write out the acceptanceRate
+	            dataset = h5f_.createDataSet<NSL::size_t>(
+                    baseNode+"/acceptanceRate",
+                    HighFive::DataSpace::From(static_cast <NSL::size_t> (markovstate.accepted))
+                );
+	            
+                dataset.write(static_cast <NSL::size_t> (markovstate.accepted));
+
 	            // write out the weights (eg logdetJ, etc. . .)
 	            for (auto [key,field] : markovstate.weights) {
 	                dataset = h5f_.createDataSet<std::complex<NSL::RealTypeOf<Type>>>(
@@ -132,6 +140,13 @@ class H5IO {
                     HighFive::DataSpace::From(markovstate.acceptanceProbability)
                 );
 	            dataset.write(markovstate.acceptanceProbability);
+
+                // write out the acceptanceRate
+	            dataset = h5f_.createDataSet<NSL::size_t>(
+                    baseNode+"/acceptanceRate",
+                    HighFive::DataSpace::From(static_cast <NSL::size_t> (markovstate.accepted))
+                );
+                dataset.write(static_cast <NSL::size_t> (markovstate.accepted));
 
 	            // write out the weights (eg logdetJ, etc. . .)
 	            for (auto [key,field] : markovstate.weights) {
@@ -200,6 +215,10 @@ class H5IO {
 	            dataset = h5f_.getDataSet(baseNode+"/acceptanceProbability");
 	            dataset.read(markovstate.acceptanceProbability);
 
+                // read in the acceptanceProbability
+	            dataset = h5f_.getDataSet(baseNode+"/acceptanceRate");
+	            dataset.read(markovstate.accepted);
+
 	            // read in the weights (eg logdetJ, etc. . .)
 	            for (auto & [key,field] : markovstate.weights) {
 	                dataset = h5f_.getDataSet(baseNode+"/weights/"+key);
@@ -216,6 +235,10 @@ class H5IO {
 	            // read in the acceptanceProbability
 	            dataset = h5f_.getDataSet(baseNode+"/acceptanceProbability");
 	            dataset.read(markovstate.acceptanceProbability);
+
+                // read in the acceptanceProbability
+	            dataset = h5f_.getDataSet(baseNode+"/acceptanceRate");
+	            dataset.read(markovstate.accepted);
 
 	            // read in the weights (eg logdetJ, etc. . .)
 	            for (auto & [key,field] : markovstate.weights) {

--- a/src/NSL/LinAlg.hpp
+++ b/src/NSL/LinAlg.hpp
@@ -9,6 +9,7 @@
 #include "LinAlg/det.tpp"
 #include "LinAlg/transpose.tpp"
 #include "LinAlg/exp.tpp"
+#include "LinAlg/flip.tpp"
 #include "LinAlg/log.tpp"
 #include "LinAlg/inner_product.tpp"
 #include "LinAlg/mat_exp.tpp"

--- a/src/NSL/LinAlg.hpp
+++ b/src/NSL/LinAlg.hpp
@@ -20,6 +20,7 @@
 #include "LinAlg/mat_inv.tpp"
 #include "LinAlg/eigh.tpp"
 #include "LinAlg/tensordot.tpp"
+#include "LinAlg/sqrt.tpp"
 
 #include "LinAlg/Solver/Solver.hpp"
 // includes CG.hpp

--- a/src/NSL/LinAlg/Solver/Impl/CG.hpp
+++ b/src/NSL/LinAlg/Solver/Impl/CG.hpp
@@ -29,7 +29,7 @@ class CG: public NSL::LinAlg::Solver<Type> {
          * This Solver implementation uses the conjugate gradient (CG) algorithm.
          * */
         CG(std::function<NSL::Tensor<Type>(const NSL::Tensor<Type> &)> M,
-               const typename NSL::RT_extractor<Type>::type eps = 1e-6, const NSL::size_t maxIter = 10000) : 
+               const typename NSL::RT_extractor<Type>::type eps = 1e-12, const NSL::size_t maxIter = 10000) : 
             NSL::LinAlg::Solver<Type>(M),
             errSq_(eps*eps),
             maxIter_(maxIter),
@@ -81,7 +81,7 @@ class CG: public NSL::LinAlg::Solver<Type> {
             // to ensure that the required interface is given.
             requires( NSL::Concept::isDerived<FermionMatrix<Type,LatticeType>,NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> )
         CG(FermionMatrix<Type,LatticeType> & M,
-               const typename NSL::RT_extractor<Type>::type eps = 1e-6, const NSL::size_t maxIter = 10000) : 
+               const typename NSL::RT_extractor<Type>::type eps = 1e-12, const NSL::size_t maxIter = 10000) : 
             NSL::LinAlg::Solver<Type>(M, NSL::FermionMatrix::M),
             errSq_(eps*eps),
             maxIter_(maxIter),

--- a/src/NSL/LinAlg/Solver/Impl/CG.hpp
+++ b/src/NSL/LinAlg/Solver/Impl/CG.hpp
@@ -141,7 +141,7 @@ class CG: public NSL::LinAlg::Solver<Type> {
             requires( NSL::Concept::isDerived<FermionMatrix<Type,LatticeType>,NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> )
         CG(FermionMatrix<Type,LatticeType> & M, 
                NSL::FermionMatrix::MatrixCombination matrixCombination,
-               const typename NSL::RT_extractor<Type>::type eps = 1e-6, const NSL::size_t maxIter = 10000) : 
+               const typename NSL::RT_extractor<Type>::type eps = 1e-12, const NSL::size_t maxIter = 10000) : 
             NSL::LinAlg::Solver<Type>(M,matrixCombination),
             errSq_(eps*eps),
             maxIter_(maxIter),

--- a/src/NSL/LinAlg/Solver/Impl/CG.tpp
+++ b/src/NSL/LinAlg/Solver/Impl/CG.tpp
@@ -40,7 +40,7 @@ NSL::Tensor<Type> CG<Type>::operator()(const NSL::Tensor<Type> & b ){
     
     // if the guess is already good enough return
     if (rsqr_curr <= errSq_) {
-        NSL::Logger::info("CG Converged with precision: {} < {} after {} steps", rsqr_curr,errSq_,0);
+        NSL::Logger::info("CG Converged with precision: {} < {} after {} steps", NSL::LinAlg::sqrt(rsqr_curr),NSL::LinAlg::sqrt(errSq_),0);
         return x_;
     }
 
@@ -73,7 +73,7 @@ NSL::Tensor<Type> CG<Type>::operator()(const NSL::Tensor<Type> & b ){
         // parameter eps (errSq_ = eps*eps) of the constructor to this class
         // if succeeded return the solution x_ = M^{-1} b;
         if (rsqr_curr <= errSq_) {
-            NSL::Logger::info("CG Converged with precision: {} < {} after {} steps", rsqr_curr,errSq_,count);
+            NSL::Logger::info("CG Converged with precision: {} < {} after {} steps", NSL::LinAlg::sqrt(rsqr_curr),NSL::LinAlg::sqrt(errSq_),count);
             return x_;
         }
 
@@ -92,7 +92,7 @@ NSL::Tensor<Type> CG<Type>::operator()(const NSL::Tensor<Type> & b ){
         NSL::Logger::debug("CG Iteration: {}/{} | α = {} | ε² = {} |  β = {}", count, maxIter_, NSL::to_string(alpha), rsqr_curr, beta);
     } // for(counter)
 
-    NSL::Logger::error("Error CG did not converge within {} iterations! |r|^2 = {}", maxIter_, rsqr_prev);
+    NSL::Logger::error("Error CG did not converge within {} iterations! |r| = {}", maxIter_, NSL::LinAlg::sqrt(rsqr_prev));
 
     // this should never be reached but put it just in case something goes wrong.
     return x_;

--- a/src/NSL/LinAlg/flip.tpp
+++ b/src/NSL/LinAlg/flip.tpp
@@ -7,7 +7,6 @@ namespace NSL::LinAlg  {
 
 template<NSL::Concept::isNumber Type>
 inline NSL::Tensor<Type> flip( const NSL::Tensor<Type> & t, std::vector<NSL::size_t> dims){
-
     return torch::flip(
         t,dims
     );

--- a/src/NSL/LinAlg/flip.tpp
+++ b/src/NSL/LinAlg/flip.tpp
@@ -1,0 +1,19 @@
+#ifndef NSL_LINALG_FLIP_TPP
+#define NSL_LINALG_FLIP_TPP
+
+#include "../Tensor.hpp"
+
+namespace NSL::LinAlg  {
+
+template<NSL::Concept::isNumber Type>
+inline NSL::Tensor<Type> flip( const NSL::Tensor<Type> & t, std::vector<NSL::size_t> dims){
+
+    return torch::flip(
+        t,dims
+    );
+
+}
+
+} // namespace NSL::LinAlg
+
+#endif // NSL_LINALG_FLIP_TPP

--- a/src/NSL/LinAlg/inner_product.tpp
+++ b/src/NSL/LinAlg/inner_product.tpp
@@ -32,6 +32,11 @@ Type inner_product(const NSL::Tensor<Type> & a, const NSL::Tensor<Type> & b ){
     return (NSL::LinAlg::conj(a)*b).sum();
 }
 
+template<NSL::Concept::isNumber Type>
+NSL::Tensor<Type> inner_product(const NSL::Tensor<Type> & a, const NSL::Tensor<Type> & b , const NSL::size_t & dim){
+    return (NSL::LinAlg::conj(a)*b).sum(dim);
+}
+
 //! Inner product of tensor a and b.
 /*! 
  * Computes the dot product for 1D tensors. For higher dimensions, sums the product of elements from input and other along their last dimension.

--- a/src/NSL/LinAlg/sqrt.tpp
+++ b/src/NSL/LinAlg/sqrt.tpp
@@ -1,0 +1,23 @@
+#ifndef NSL_LINALG_SQRT_HPP
+#define NSL_LINALG_SQRT_HPP
+
+#include <cmath>
+#include "../Tensor.hpp"
+
+namespace NSL::LinAlg {
+
+//! log(Type)
+template<NSL::Concept::isNumber Type>
+Type sqrt(Type number){
+    return std::sqrt(number);
+}
+
+//! log(Tensor) - element wise 
+template<NSL::Concept::isNumber Type>
+NSL::Tensor<Type> sqrt(const Tensor<Type> & t) {
+    return NSL::Tensor<Type>(t,true).sqrt();
+}
+
+} // namespace NSL::LinAlg
+
+#endif //NSL_LINALG_SQRT_HPP

--- a/src/NSL/MarkovChain/HMC.tpp
+++ b/src/NSL/MarkovChain/HMC.tpp
@@ -89,8 +89,7 @@ class HMC{
                 }
                 catch(...) {
                 // in case the last markov state is corrupted try again
-                    // h5_.removeData(fmt::format("{}/{}",baseNode,nstart));
-                    h5_.trimData(fmt::format("{}/{}",baseNode,nstart));
+                    h5_.deleteData(fmt::format("{}/{}",baseNode,nstart));
                     nstart--;
                     MC[nstart] = state;
                     h5_.read(MC[nstart], baseNode, nstart);

--- a/src/NSL/MarkovChain/HMC.tpp
+++ b/src/NSL/MarkovChain/HMC.tpp
@@ -89,8 +89,10 @@ class HMC{
                 }
                 catch(...) {
                 // in case the last markov state is corrupted try again
-                    h5_.removeData(fmt::format("{}/{}",baseNode,nstart));
+                    // h5_.removeData(fmt::format("{}/{}",baseNode,nstart));
+                    h5_.trimData(fmt::format("{}/{}",baseNode,nstart));
                     nstart--;
+                    MC[nstart] = state;
                     h5_.read(MC[nstart], baseNode, nstart);
                 }
 

--- a/src/NSL/MarkovChain/HMC.tpp
+++ b/src/NSL/MarkovChain/HMC.tpp
@@ -84,7 +84,15 @@ class HMC{
             if (nstart > 0){
                 // this reader looks for the most recent markov state and reads it into the state
                 MC[nstart] = state;
-                h5_.read(MC[nstart], baseNode);
+                try {
+                    h5_.read(MC[nstart], baseNode);
+                }
+                catch(...) {
+                // in case the last markov state is corrupted try again
+                    h5_.removeData(fmt::format("{}/{}",baseNode,nstart));
+                    nstart--;
+                    h5_.read(MC[nstart], baseNode, nstart);
+                }
 
             } else{
                 MC[nstart] = state;

--- a/src/NSL/MarkovChain/HMC.tpp
+++ b/src/NSL/MarkovChain/HMC.tpp
@@ -93,6 +93,7 @@ class HMC{
             }
 
             double runningAcceptance = 0;
+            NSL::size_t backWindow = 100;
 
             // generate Nconf-1 configurations
             auto mc_time = NSL::Logger::start_profile("HMC");
@@ -109,10 +110,13 @@ class HMC{
 		        h5_.write(MC[n],fmt::format("{}/{}",baseNode,n));
 
                 runningAcceptance += static_cast<double>(MC[n].accepted);
-
+                if ((n-backWindow) > 0) {
+                    runningAcceptance -= static_cast<double>(MC[n-backWindow].accepted);
+                }
+                
                 // ToDo: have a proper hook being called here
                 if (n % logFrequency == 0){
-                    NSL::Logger::info("HMC: {}/{}; Running Acceptence Rate: {:.6}%", n, Nconf, runningAcceptance*100./(n-nstart));
+                    NSL::Logger::info("HMC: {}/{}; Running Acceptence Rate: {:.6}%", n, Nconf, runningAcceptance/* *100. / backWindow (n-nstart) */ );
                     NSL::Logger::elapsed_profile(mc_time);
                 }
             }

--- a/src/NSL/Measurements.hpp
+++ b/src/NSL/Measurements.hpp
@@ -2,5 +2,6 @@
 #define NSL_MEASURE_HPP
 
 #include "Measurements/Hubbard/twoPointCorrelationFunction.tpp"
+#include "Measurements/Hubbard/twoBodyCorrelationFunction.tpp"
 
 #endif //NSL_MEASURE_HPP

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -16,6 +16,7 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 class TwoBodyCorrelator: public Measurement {
+    typedef std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> d4Map;
     public:
         TwoBodyCorrelator(LatticeType & lattice, NSL::Parameter params, NSL::H5IO & h5, std::string basenode_):
             Measurement(params, h5),
@@ -164,20 +165,20 @@ class TwoBodyCorrelator: public Measurement {
         std::unordered_map<NSL::Hubbard::Species, NSL::Tensor<Type>> corrPoolDag_;
         NSL::Tensor<Type> srcVecK_;
 
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz1Sz1_;
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz1Sz0_;
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz1Szn1_;
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz0Sz1_;
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz0Szn1_;
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Izn1Sz1_;
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Izn1Sz0_;
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Izn1Szn1_;
+        d4Map cI1S1Iz1Sz1_;
+        d4Map cI1S1Iz1Sz0_;
+        d4Map cI1S1Iz1Szn1_;
+        d4Map cI1S1Iz0Sz1_;
+        d4Map cI1S1Iz0Szn1_;
+        d4Map cI1S1Izn1Sz1_;
+        d4Map cI1S1Izn1Sz0_;
+        d4Map cI1S1Izn1Szn1_;
 
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI0S1Iz0Sz1_;
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI0S1Iz0Szn1_;
+        d4Map cI0S1Iz0Sz1_;
+        d4Map cI0S1Iz0Szn1_;
 
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S0Iz1Sz0_;
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S0Izn1Sz0_;
+        d4Map cI1S0Iz1Sz0_;
+        d4Map cI1S0Izn1Sz0_;
 
         NSL::Tensor<Type> phi_;
 
@@ -219,31 +220,31 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
         for (int x=0; x<kDim; x++) {
             for (int y=0; y<kDim; y++) {
                 for (int z=0; z<kDim; z++) {
-                    if (!(eq_modBZ_(momenta(w,NSL::Slice()) + momenta(x,NSL::Slice()), momenta(z, NSL::Slice()) + momenta(y,NSL::Slice())))) {
+                    if (!(eq_modBZ_(momenta(w, NSL::Slice()) + momenta(x, NSL::Slice()), momenta(z, NSL::Slice()) + momenta(y, NSL::Slice())))) {
                         continue;
                     }
-                    cI1S1Iz1Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz1Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz0Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz0Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Izn1Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Izn1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz1Sz1_[w][x][z][y]   = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz1Sz0_[w][x][z][y]   = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz1Szn1_[w][x][z][y]  = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz0Sz1_[w][x][z][y]   = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz0Szn1_[w][x][z][y]  = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Izn1Sz1_[w][x][z][y]  = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Izn1Sz0_[w][x][z][y]  = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
                     cI1S1Izn1Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
 
-                    cI0S1Iz0Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI0S1Iz0Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI0S1Iz0Sz1_[w][x][z][y]   = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI0S1Iz0Szn1_[w][x][z][y]  = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
 
-                    cI1S0Iz1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S0Izn1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S0Iz1Sz0_[w][x][z][y]   = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S0Izn1Sz0_[w][x][z][y]  = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
                 }
             }
         }
     }
-    corrPool_[NSL::Hubbard::Particle] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
-    corrPool_[NSL::Hubbard::Hole] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
+    corrPool_[NSL::Hubbard::Particle]    = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
+    corrPool_[NSL::Hubbard::Hole]        = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
     corrPoolDag_[NSL::Hubbard::Particle] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
-    corrPoolDag_[NSL::Hubbard::Hole] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
+    corrPoolDag_[NSL::Hubbard::Hole]     = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
 
 
     for (NSL::size_t tsrc = 0; tsrc<Nt; tsrc+=tsrcStep) {
@@ -258,7 +259,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
 
             for (int kSrc=0; kSrc<kDim; kSrc++ ) {
                 // Define a wall source
-                srcVecK_(NSL::Slice(),tsrc,NSL::Slice()) = NSL::Tensor<NSL::complex<double>> (params_["wallSources"])(kSrc,NSL::Slice(),NSL::Slice());
+                srcVecK_(NSL::Slice(),tsrc,NSL::Slice()) = NSL::Tensor<NSL::complex<double>> (params_["wallSources"])(kSrc,NSL::Slice(),NSL::Slice()); // Maybe explicitly send it to device
 
                 // invert MM^dagger
                 NSL::Tensor<Type> invMMdag = cg_(srcVecK_);
@@ -271,19 +272,19 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
 
                 // back multiply M^dagger to obtain M^{-1}
                 // invM is of shape Nx x Nt x Nx
-                NSL::Tensor<Type> invM = hfm_.Mdagger(invMMdag);
-                NSL::Tensor<Type> invMdagger = hfm_.M(invMdagM);
+                corrK_ = hfm_.Mdagger(invMMdag);
+                corrKDag_ = hfm_.M(invMdagM);
 
                 // We shift the 1st axis (time-axis) if invM by tsrc and apply anti periodic 
                 // boundary conditions
                 // shift t -> t - tsrc
-                invM.shift( -tsrc, -2, -Type(1) );
-                invMdagger.shift( -tsrc, -2, -Type(1) );
+                corrK_.shift( -tsrc, -2, -Type(1) );
+                corrKDag_.shift( -tsrc, -2, -Type(1) );
 
                 // Average over all source times
                 // corrK_ += invM; // I changed something here!!!!!
-                corrK_ = invM;
-                corrKDag_ = invMdagger;
+                // corrK_ = invM;
+                // corrKDag_ = invMdagger;
 
                 for (int kSink=0; kSink<kDim; kSink++) {
                     for (NSL::size_t t = 0; t<Nt; t++) {
@@ -361,43 +362,45 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
                     	momNode = fmt::format("/cI1S1Iz1Sz1/{}-{}-{}-{}",w,x,z,y);
                     	this->h5_.write(cI1S1Iz1Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                   	 momNode = fmt::format("/cI1S1Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
-                    	 this->h5_.write(cI1S1Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
+                   	    momNode = fmt::format("/cI1S1Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI1S1Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    	 momNode = fmt::format("/cI1S1Iz1Szn1/{}-{}-{}-{}",w,x,z,y);
-                    	 this->h5_.write(cI1S1Iz1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	momNode = fmt::format("/cI1S1Iz1Szn1/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI1S1Iz1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    	 momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
-                    	 this->h5_.write(cI1S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI1S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    	 momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
-                    	 this->h5_.write(cI1S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI1S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    	 momNode = fmt::format("/cI1S1Izn1Sz1/{}-{}-{}-{}",w,x,z,y);
-                    	 this->h5_.write(cI1S1Izn1Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	momNode = fmt::format("/cI1S1Izn1Sz1/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI1S1Izn1Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    	 momNode = fmt::format("/cI1S1Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
-                    	 this->h5_.write(cI1S1Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	momNode = fmt::format("/cI1S1Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI1S1Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    	 momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",w,x,z,y);
-                    	 this->h5_.write(cI1S1Izn1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI1S1Izn1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    	 momNode = fmt::format("/cI0S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
-                    	 this->h5_.write(cI0S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-			 momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
-                    	 this->h5_.write(cI0S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	momNode = fmt::format("/cI0S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI0S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    	 momNode = fmt::format("/cI1S0Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
-                    	 this->h5_.write(cI1S0Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
+			            momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI0S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-			 momNode = fmt::format("/cI1S0Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
-                    	 this->h5_.write(cI1S0Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
-                	 }
-            	     }
-       		 }
-    	    }
-        } else {
+
+                    	momNode = fmt::format("/cI1S0Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI1S0Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
+
+			            momNode = fmt::format("/cI1S0Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI1S0Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
+                	}
+            	}
+       		}
+    	}
+    } else {
         NSL::Logger::info("Non-interacting correlators already exist");
     }
     // Interacting Correlators
@@ -413,8 +416,6 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
     bool trimFlag = false;
     // Determine the number of time sources:
     for (NSL::size_t cfgID = minCfg; cfgID<=maxCfg; ++cfgID){
-        // this is a shortcut, we don't need to invert if we don't overwrite
-        // data
 
         node = fmt::format("/markovChain/{}/correlators/twobody",cfgID);
 
@@ -469,12 +470,14 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
 
                         momNode = fmt::format("/cI0S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
                         this->h5_.write(cI0S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
+
                         momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
                         this->h5_.write(cI0S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
 
                         momNode = fmt::format("/cI1S0Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
                         this->h5_.write(cI1S0Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
+
                         momNode = fmt::format("/cI1S0Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
                         this->h5_.write(cI1S0Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
                     }

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -81,7 +81,6 @@ class TwoBodyCorrelator: public Measurement {
         }
 
         bool eq_modBZ_(const NSL::Tensor<double>& k, const NSL::Tensor<double>& q, double eps = 1e-15) {
-            // std::cout << "WE ARE HERE" << std::endl;
             NSL::Tensor<double> diff = k-q;
             // These two vectors are linearly independent vectors that take us to
             // Gamma points in neighboring cells in the reciprocal lattice.
@@ -155,7 +154,11 @@ class TwoBodyCorrelator: public Measurement {
         std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Izn1Sz0_;
         std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Izn1Szn1_;
 
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI0S1Iz0Sz1_;
         std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI0S1Iz0Szn1_;
+
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S0Iz1Sz0_;
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S0Izn1Sz0_;
 
         NSL::Tensor<Type> phi_;
 
@@ -170,7 +173,11 @@ class TwoBodyCorrelator: public Measurement {
         void I1S1Izn1Sz0_();
         void I1S1Izn1Szn1_();
 
+        void I0S1Iz0Sz1_();
         void I0S1Iz0Szn1_();
+
+        void I1S0Iz1Sz0_();
+        void I1S0Izn1Sz0_();
 };
 
 
@@ -206,7 +213,11 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
                     cI1S1Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
                     cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
 
+                    cI0S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
                     cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+
+                    cI1S0Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+                    cI1S0Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
                 }
             }
         }
@@ -275,7 +286,11 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
         I1S1Izn1Sz0_();
         I1S1Izn1Szn1_();
 
+        I0S1Iz0Sz1_();
         I0S1Iz0Szn1_();
+
+        I1S0Iz1Sz0_();
+        I1S0Izn1Sz0_();
     } // for tscr
 
 } // measure(Ntsrc);
@@ -333,8 +348,15 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
                     this->h5_.write(cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
 
 
+                    momNode = fmt::format("/cI0S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI0S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
                     momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
                     this->h5_.write(cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                    momNode = fmt::format("/cI1S0Iz1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S0Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S0Izn1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S0Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
                 }
             }
         }
@@ -399,8 +421,15 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
                         this->h5_.write(cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
 
 
+                        momNode = fmt::format("/cI0S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI0S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
                         momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
                         this->h5_.write(cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                        momNode = fmt::format("/cI1S0Iz1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S0Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S0Izn1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S0Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
                     }
                 }
             }
@@ -797,6 +826,54 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Sz1_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+
+    std::vector<NSL::size_t> tDim{0};
+
+    for ( const auto &[kSinkPart, value1]: cI0S1Iz0Sz1_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+
+                                    cI0S1Iz0Sz1_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
+                                    
+                                    += (0.5 * ((NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)
+                                    
+                                    + NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim)
+                                    
+                                    + NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim)
+                                    
+                                    + NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)) 
+                                    
+                                    / Type(params_["Number Time Sources"])));
+
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Szn1_() {
     int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
@@ -828,6 +905,100 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Szn1_() {
                                     
                                     / Type(params_["Number Time Sources"])));
 
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Iz1Sz0_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+
+    std::vector<NSL::size_t> tDim{0};
+
+    for ( const auto &[kSinkPart, value1]: cI1S0Iz1Sz0_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+
+                                    cI1S0Iz1Sz0_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
+                                    
+                                    += -1*(0.5 * ((NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim) 
+                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)
+                                    
+                                    + NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim) 
+                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart)
+                                    
+                                    + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim)
+                                    
+                                    + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)) 
+                                    
+                                    / Type(params_["Number Time Sources"])));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Izn1Sz0_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+
+    std::vector<NSL::size_t> tDim{0};
+
+    for ( const auto &[kSinkPart, value1]: cI1S0Izn1Sz0_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+
+                                    cI1S0Izn1Sz0_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
+                                    
+                                    += -1*(0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)
+                                    
+                                    + corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim)
+                                    
+                                    + NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim) 
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart)
+                                    
+                                    + NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim) 
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)) 
+                                    
+                                    / Type(params_["Number Time Sources"])));
                                 }
                             }
                         }

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -447,7 +447,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
 	    }
 
         if (trimFlag) {
-            this->h5_.trimData(node);
+            this->h5_.deleteData(node);
             trimFlag = false;
         }
         

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -1,0 +1,500 @@
+#ifndef NSL_TWO_BODY_CORRELATION_FUNCTION_TPP
+#define NSL_TWO_BODY_CORRELATION_FUNCTION_TPP
+
+#include "Configuration/Configuration.tpp"
+#include "concepts.hpp"
+#include "device.tpp"
+#include "parameter.tpp"
+#include "../measure.hpp"
+
+
+namespace NSL::Measure::Hubbard {
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+class TwoBodyCorrelator: public Measurement {
+    public:
+        TwoBodyCorrelator(LatticeType & lattice, NSL::Parameter params, NSL::H5IO & h5, std::string basenode_):
+            Measurement(params, h5),
+            hfm_(lattice, params),
+            cg_(hfm_, NSL::FermionMatrix::MMdagger),
+            corrKblock_(
+                params["device"].to<NSL::Device>(),
+                params["Nt"].to<NSL::size_t>(),
+                params["wallSources"].shape(1).to<NSL::size_t>(),
+                params["wallSources"].shape(1).to<NSL::size_t>()
+                ),
+            corrK_(
+                params["device"].to<NSL::Device>(),
+                params["wallSources"].shape(1).to<NSL::size_t>(),
+                params["Nt"].to<NSL::size_t>(),
+                params["Nx"].to<NSL::size_t>()
+                ),
+            corrKPool_(
+                params["device"].to<NSL::Device>(),
+                params["wallSources"].shape(0).to<NSL::size_t>(),
+                params["wallSources"].shape(0).to<NSL::size_t>(),
+                // NSL::size_t (species_.size()), // I want to have a size 2 in this place
+                params["Nt"].to<NSL::size_t>(),
+                params["wallSources"].shape(1).to<NSL::size_t>(),
+                params["wallSources"].shape(1).to<NSL::size_t>()
+                ),
+            corr_(
+                params["device"].to<NSL::Device>(),
+                params["Nt"].to<NSL::size_t>(),
+                params["Nx"].to<NSL::size_t>(),
+                params["Nx"].to<NSL::size_t>()
+            ),
+	        srcVecK_(
+                params["device"].to<NSL::Device>(),
+                params["wallSources"].shape(1).to<NSL::size_t>(),
+                params["Nt"].to<NSL::size_t>(),
+                params["Nx"].to<NSL::size_t>()
+            ),
+            phi_(
+                params["device"].to<NSL::Device>(),
+                params["Nt"].to<NSL::size_t>(),
+                params["Nx"].to<NSL::size_t>()
+            ),
+            basenode_(basenode_)
+        {}
+
+        TwoBodyCorrelator(LatticeType & lattice, NSL::Parameter params,NSL::H5IO & h5):
+            TwoBodyCorrelator(
+                lattice,
+                params,
+                h5, 
+                params["name"]
+            )
+        {}
+
+        //! Calculate the \f( N_t \times N_x \times N_x \f) correlators, i.e. 
+        //! Propagators with averaged second time coordinate
+        void measure() override;
+
+        void measure(NSL::size_t NumberTimeSources);
+
+    protected:
+        bool skip_(bool overwrite, std::string node){
+            bool exists = this->h5_.exist(fmt::format("{}{}",std::string(basenode_),node));
+
+            // if overwrite is specified always calculate the correlator
+            if (overwrite){return false;}
+
+            // if correlator doesn't exist always calculate it
+            if (not exists){return false;}
+
+            // if correlator exists only recompute if overwrite is true 
+            // (this is the only remaining case)
+            return true;
+        }
+
+        bool eq_modBZ(const NSL::Tensor<double>& k, const NSL::Tensor<double>& q, double eps = 1e-15) {
+            // std::cout << "WE ARE HERE" << std::endl;
+            NSL::Tensor<double> diff = k-q;
+            // These two vectors are linearly independent vectors that take us to
+            // Gamma points in neighboring cells in the reciprocal lattice.
+            std::vector<double> Cv = {4 * M_PI / 3, 0};
+            std::vector<double> Dv = {-2 * M_PI /3, 2 * M_PI / sqrt(3.0)};
+
+            NSL::Tensor<double> C(Cv.size());
+            C = Cv;
+            NSL::Tensor<double> D(Dv.size());
+            D = Dv;
+
+            // Two vectors are equal (mod BZ) if their difference is 0 (mod BZ).
+            // In practice, that means an integer number of 'jumps' between them.
+            // In other words, if
+            //     k = a  C + b  D + remainder      with integers a , b
+            //     q = a' C + b' D + remainder'     with integers a', b'
+            // Then k = q (mod BZ) if remainder = remainder'.
+            // Subtracting,
+            // 0 = (k-q) = (a-a') C + (b-b') D + (remainder-remainder')
+            //           = m C + n D + ZERO
+            //           = m C + n D with integers m, n.
+            // So, we can solve
+            // diff = m C + n D for m,n
+            // and if they are integers, k and q are equal (mod BZ).
+            double denominator = C(1) * D(0) - C(0) * D(1);
+            double m = (diff(1) * D(0) - diff(0) * D(1)) / denominator;
+            double n = (diff(0) * C(1) - diff(1) * C(0)) / denominator;
+            
+            return (abs(round(m)- m) < eps && abs(round(n)- n) < eps);
+            // if (abs(round(m)- m) < eps && abs(round(n)- n) < eps) return true;
+
+            // return false;
+        }
+
+        NSL::Tensor<Type> kroneckerProduct(const NSL::Tensor<Type>& A, const NSL::Tensor<Type>& B) {
+            
+            int rowsA = A.shape(1);
+            int colsA = A.shape(2);
+            int rowsB = B.shape(1);
+            int colsB = B.shape(2);
+
+            // Result Tensor has shape ( (rowsA*rowsB) x (colsA*colsB) )
+            NSL::Tensor<Type> result(params_["device"].to<NSL::Device>(), A.shape(0), rowsA * rowsB, colsA * colsB);
+
+            for (int i = 0; i < rowsA; ++i) {
+                for (int j = 0; j < colsA; ++j) {
+                    for (int k = 0; k < rowsB; ++k) {
+                        for (int l = 0; l < colsB; ++l) {
+                            result(NSL::Slice(), i * rowsB + k, j * colsB + l) = A(NSL::Slice(),i,j) * B(NSL::Slice(),k,l);
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+
+        FermionMatrixType hfm_;
+        NSL::LinAlg::CG<Type> cg_;
+
+        NSL::Tensor<Type> corr_;
+        NSL::Tensor<Type> corrK_;
+        NSL::Tensor<Type> corrKblock_;
+        NSL::Tensor<Type> corrKPool_;
+        std::unordered_map<NSL::Hubbard::Species, NSL::Tensor<Type>> corrPool_;
+        NSL::Tensor<Type> srcVecK_;
+
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Izn1Szn1_;
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz0Szn1_;
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI0S1Iz0Szn1_;
+
+        NSL::Tensor<Type> phi_;
+
+        std::string basenode_;
+
+        void I1S1Izn1Szn1_();
+        void I1S1Iz0Szn1_();
+        void I0S1Iz0Szn1_();
+};
+
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t NumberTimeSources) {
+    NSL::size_t Nx = this->params_["Nx"].template to<NSL::size_t>();
+    NSL::size_t Nt = this->params_["Nt"].template to<NSL::size_t>();
+    
+    NSL::size_t tsrcStep = Nt/NumberTimeSources;
+
+    // Reset memory
+    // - Result correlator
+    corrK_ = Type(0);
+    corrKblock_ = Type(0);
+    // Reset memory
+    // - Source vector
+    srcVecK_ = Type(0);
+
+    int kDim = params_["wallSources"].shape(0);
+    int bDim = params_["wallSources"].shape(1);
+
+    NSL::Tensor<double> momenta = params_["momenta"];
+    for (int kSinkPart=0; kSinkPart<kDim; kSinkPart++) {
+        for (int kSinkHole=0; kSinkHole<kDim; kSinkHole++) {
+            for (int kSrcHole=0; kSrcHole<kDim; kSrcHole++) {
+                for (int kSrcPart=0; kSrcPart<kDim; kSrcPart++) {
+                    if (!(eq_modBZ(momenta(kSinkPart,NSL::Slice()) + momenta(kSinkHole,NSL::Slice()), momenta(kSrcPart, NSL::Slice()) + momenta(kSrcHole,NSL::Slice())))) {
+                        continue;
+                    }
+                    cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    // cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+                    cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                }
+            }
+        }
+    }
+    corrPool_[NSL::Hubbard::Particle] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
+    corrPool_[NSL::Hubbard::Hole] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
+
+    for (NSL::size_t tsrc = 0; tsrc<Nt; tsrc+=tsrcStep) {
+        
+        for (NSL::Hubbard::Species species : {NSL::Hubbard::Particle, NSL::Hubbard::Hole}) {
+            // populate the fermion matrix using the free configuration
+            hfm_.populate(phi_,species);
+
+            for (int kSrc=0; kSrc<kDim; kSrc++ ) {
+                // Define a wall source
+                srcVecK_(NSL::Slice(),tsrc,NSL::Slice()) = NSL::Tensor<NSL::complex<double>> (params_["wallSources"])(kSrc,NSL::Slice(),NSL::Slice());
+
+                // invert MM^dagger
+                NSL::Tensor<Type> invMMdag = cg_(srcVecK_);
+
+                // back multiply M^dagger to obtain M^{-1}
+                // invM is of shape Nx x Nt x Nx
+                NSL::Tensor<Type> invM = hfm_.Mdagger(invMMdag);
+
+                // Using a point sink allows to just copy invM as corr(t,y,x)
+                // We shift the 1st axis (time-axis) if invM by tsrc and apply anti periodic 
+                // boundary conditions
+                // shift t -> t - tsrc
+                invM.shift( -tsrc, -2, -Type(1) );
+
+                // Average over all source times
+                // corrK_ += invM; // I changed something here!!!!!
+                corrK_ = invM;
+
+                srcVecK_ = Type(0);
+
+                for (int kSink=0; kSink<kDim; kSink++) {
+                    for (NSL::size_t t = 0; t<Nt; t++) {
+                        for (int sigmaSink=0; sigmaSink<bDim; sigmaSink++) {
+                            for (int sigmaSrc=0; sigmaSrc<bDim; sigmaSrc++) {
+                                corrKPool_(kSink,kSrc,t,sigmaSink,sigmaSrc) = NSL::LinAlg::inner_product( NSL::Tensor<NSL::complex<double>> (params_["wallSources"])(kSink,sigmaSink,NSL::Slice()),corrK_(sigmaSrc,t,NSL::Slice()));
+                            }
+                        }
+                    }
+                }
+            } // for kSrc
+
+            corrPool_[species] = corrKPool_;
+        } // for species
+
+        I1S1Izn1Szn1_();
+        I1S1Iz0Szn1_();
+        I0S1Iz0Szn1_();
+    } // for tscr
+
+} // measure(Ntsrc);
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
+    NSL::Logger::info("Start Measuring Hubbard::TwoPointCorrelator");
+
+    // This is the default basenode we used so far
+    // ToDo: this should go into the const
+
+    // write the non interacting correlator 
+    std::string node;
+    node = "/NonInteracting/correlators/twobody";
+    // this is a shortcut, we don't need to calculate the non-interacting 
+    // correlators if we won't update the file
+
+    // measure the non-interacting theory
+    // U = 0 <=> phi = 0
+    phi_ = Type(0);
+
+    measure(1);
+    std::string momNode;
+    for ( const auto &[kSinkPart, value1]: cI1S1Izn1Szn1_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+                    // write the result
+                    momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                    momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                    momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                }
+            }
+        }
+    }
+    // Interacting Correlators
+    // Initialize memory for the configurations
+    // get the range of configuration ids from the h5file
+    auto [minCfg, maxCfg] = this->h5_.getMinMaxConfigs(std::string(basenode_)+"/markovChain");
+    NSL::size_t saveFreq = this->params_["save frequency"];
+    
+    NSL::Logger::info("Found trajectories: {} to {} with save frequency {}",
+        minCfg, maxCfg, saveFreq
+    );
+
+    // Determine the number of time sources:
+    for (NSL::size_t cfgID = minCfg; cfgID<=maxCfg; ++cfgID){
+        // this is a shortcut, we don't need to invert if we don't overwrite
+        // data
+
+        node = fmt::format("/markovChain/{}/correlators/twobody",cfgID);
+
+        if (skip_(this->params_["overwrite"],node)) {
+            NSL::Logger::info("Config #{} already has correlators, skipping... ", cfgID);
+	        continue;
+	    } 
+
+        NSL::Logger::info("Calculating Correlator on {}/{}", cfgID, maxCfg);
+
+        // read configuration 
+        this->h5_.read(phi_,fmt::format("{}/markovChain/{}/phi",std::string(basenode_),cfgID));
+
+        // compute the correlator. The result is stored in corr_
+        measure(this->params_["Number Time Sources"]);
+        std::string momNode;
+        for ( const auto &[kSinkPart, value1]: cI1S1Izn1Szn1_ ) {
+            for ( const auto &[kSinkHole, value2]: value1 ) {
+                for ( const auto &[kSrcHole, value3]: value2 ) {
+                    for ( const auto &[kSrcPart, value4]: value3 ) {
+                        // write the result
+                        momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                        momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                        momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    }
+                }
+            }
+        }
+        
+    } // for cfgI
+
+} // measure()
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+    
+    // NSL::Tensor<Type> eye(params_["device"].to<NSL::Device>(),kDim,kDim,Nt,bDim,bDim);
+    // for (int k=0; k<kDim; k++) {
+    //     for (int nt=0;nt<Nt; nt++){
+    //         eye(k,k,nt,NSL::Slice(), NSL::Slice()) = NSL::Matrix::Identity<Type> (bDim);
+    //     }
+    // }
+
+    for ( const auto &[kSinkPart, value1]: cI1S1Izn1Szn1_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+                                    // cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(),bSinkPart * bDim + bSinkHole, bSrcHole * bDim + bSrcPart)
+                                    cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), bSinkPart, bSinkHole, bSrcHole, bSrcPart)
+                                    
+                                    += ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)
+                                    
+                                    - corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart))
+
+                                    / Type(params_["Number Time Sources"]));
+                                    
+                                    // + eye(kSinkHole, kSrcHole, NSL::Slice(), bSinkHole, bSrcHole) * corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart);
+                                }
+                            }
+                        }
+                    } 
+                }
+            }
+        }
+    }
+}
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Szn1_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+
+    for ( const auto &[kSinkPart, value1]: cI1S1Iz0Szn1_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+                                    // cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(),bSinkPart * bDim + bSinkHole, bSrcHole * bDim + bSrcPart)
+                                    cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), bSinkPart, bSinkHole, bSrcHole, bSrcPart)
+                                    
+                                    += (0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
+                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)
+                                    
+                                    - corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
+                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart)
+                                    
+                                    - corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart)
+                                    
+                                    + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)) 
+                                    
+                                    / Type(params_["Number Time Sources"])));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Szn1_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+
+    for ( const auto &[kSinkPart, value1]: cI0S1Iz0Szn1_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+                                    // cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(),bSinkPart * bDim + bSinkHole, bSrcHole * bDim + bSrcPart)
+                                    cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), bSinkPart, bSinkHole, bSrcHole, bSrcPart)
+                                    
+                                    += (0.5 * ((corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)
+                                    
+                                    + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart)
+                                    
+                                    + corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
+                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart)
+                                    
+                                    + corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
+                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)) 
+                                    
+                                    / Type(params_["Number Time Sources"])));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // namespace NSL::Measure::Hubbard
+
+#endif // NSL_TWO_POINT_CORRELATION_FUNCTION_TPP

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -547,17 +547,17 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz0_(NSL::siz
 
                                     cI1S1Iz1Sz0_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (-0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](z,w,NSL::Slice(), i,l)
+                                    += (-0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](w,z,NSL::Slice(), i,l)
                                     * corrPool_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
-                                    - corrPoolDag_[NSL::Hubbard::Particle](z,x,NSL::Slice(),i,k)
+                                    - corrPoolDag_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k)
                                     * corrPool_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l)
                                     
                                     - corrPool_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
-                                    * corrPoolDag_[NSL::Hubbard::Particle](y,w,NSL::Slice(),j,l)
+                                    * corrPoolDag_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l)
                                     
                                     + corrPool_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
-                                    * corrPoolDag_[NSL::Hubbard::Particle](y,x,NSL::Slice(),j,k)) 
+                                    * corrPoolDag_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,k)) 
                                     
                                     / Type(NumberTimeSources)));
                                 }

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -335,6 +335,12 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
     // This is the default basenode we used so far
     // ToDo: this should go into the const
 
+    // write the momenta out
+    if (!h5_.exist(std::string(basenode_)+"/Momenta")){
+        NSL::Tensor<double> momenta = params_["momenta"];
+        this->h5_.write(momenta,std::string(basenode_)+"/Momenta");
+    }
+
     // write the non interacting correlator 
     std::string node;
     node = "/NonInteracting/correlators/twobody";

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -281,8 +281,8 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
 
                 for (int kSink=0; kSink<kDim; kSink++) {
                     for (int sigmaSink=0; sigmaSink<bDim; sigmaSink++) {
+                        NSL::Tensor<Type> wallSource = NSL::Tensor<Type> (params_["wallSources"])(kSink,sigmaSink,NSL::Slice()).expand(Nt, 0);
                         for (int sigmaSrc=0; sigmaSrc<bDim; sigmaSrc++) {
-                            NSL::Tensor<Type> wallSource = NSL::Tensor<Type> (params_["wallSources"])(kSink,sigmaSink,NSL::Slice()).expand(Nt, 0);
                             // I don't understand when torch copies to cpu and when it doesn't
                             // corrKPool_(kSink,kSrc,t,sigmaSink,sigmaSrc) = NSL::LinAlg::inner_product( wallSource , corrK_(sigmaSrc,t,NSL::Slice()));
                             corrKPool_(kSink,kSrc,NSL::Slice(),sigmaSink,sigmaSrc) = NSL::LinAlg::inner_product( wallSource , corrK_(sigmaSrc,NSL::Slice(),NSL::Slice()), 1);

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -410,6 +410,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
         minCfg, maxCfg, saveFreq
     );
 
+    bool trimFlag = false;
     // Determine the number of time sources:
     for (NSL::size_t cfgID = minCfg; cfgID<=maxCfg; ++cfgID){
         // this is a shortcut, we don't need to invert if we don't overwrite
@@ -419,9 +420,15 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
 
         if (skip_(this->params_["overwrite"],node)) {
             NSL::Logger::info("Config #{} already has correlators, skipping... ", cfgID);
+            trimFlag = true;
 	        continue;
-	    } 
+	    }
 
+        if (trimFlag) {
+            this->h5_.trimData(node);
+            trimFlag = false;
+        }
+        
         NSL::Logger::info("Calculating Correlator on {}/{}", cfgID, maxCfg);
 
         // read configuration 

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -553,7 +553,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz0_(NSL::siz
 
                                     cI1S1Iz1Sz0_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (-0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](w,z,NSL::Slice(), i,l)
+                                    += (-0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l)
                                     * corrPool_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
                                     - corrPoolDag_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k)
@@ -563,7 +563,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz0_(NSL::siz
                                     * corrPoolDag_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l)
                                     
                                     + corrPool_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
-                                    * corrPoolDag_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,k)) 
+                                    * corrPoolDag_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
                                     / Type(NumberTimeSources)));
                                 }

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -146,9 +146,14 @@ class TwoBodyCorrelator: public Measurement {
         std::unordered_map<NSL::Hubbard::Species, NSL::Tensor<Type>> corrPool_;
         NSL::Tensor<Type> srcVecK_;
 
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Izn1Szn1_;
-        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz0Szn1_;
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz1Sz1_;
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz1Sz0_;
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz1Szn1_;
         std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz0Sz1_;
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz0Szn1_;
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Izn1Sz1_;
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Izn1Sz0_;
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Izn1Szn1_;
 
         std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI0S1Iz0Szn1_;
 
@@ -156,9 +161,14 @@ class TwoBodyCorrelator: public Measurement {
 
         std::string basenode_;
 
-        void I1S1Izn1Szn1_();
-        void I1S1Iz0Szn1_();
+        void I1S1Iz1Sz1_();
+        void I1S1Iz1Sz0_();
+        void I1S1Iz1Szn1_();
         void I1S1Iz0Sz1_();
+        void I1S1Iz0Szn1_();
+        void I1S1Izn1Sz1_();
+        void I1S1Izn1Sz0_();
+        void I1S1Izn1Szn1_();
 
         void I0S1Iz0Szn1_();
 };
@@ -186,10 +196,15 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
                     if (!(eq_modBZ_(momenta(kSinkPart,NSL::Slice()) + momenta(kSinkHole,NSL::Slice()), momenta(kSrcPart, NSL::Slice()) + momenta(kSrcHole,NSL::Slice())))) {
                         continue;
                     }
-                    cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+                    cI1S1Iz1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+                    cI1S1Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+                    cI1S1Iz1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+                    cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
                     // cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
                     cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
-                    cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+                    cI1S1Izn1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+                    cI1S1Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+                    cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
 
                     cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
                 }
@@ -251,9 +266,14 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
             corrPool_[species] = corrKPool_;
         } // for species
 
-        I1S1Izn1Szn1_();
-        I1S1Iz0Szn1_();
+        I1S1Iz1Sz1_();
+        I1S1Iz1Sz0_();
+        I1S1Iz1Szn1_();
         I1S1Iz0Sz1_();
+        I1S1Iz0Szn1_();
+        I1S1Izn1Sz1_();
+        I1S1Izn1Sz0_();
+        I1S1Izn1Szn1_();
 
         I0S1Iz0Szn1_();
     } // for tscr
@@ -283,19 +303,35 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
 
     measure(1);
     std::string momNode;
-    for ( const auto &[kSinkPart, value1]: cI1S1Izn1Szn1_ ) {
+    for ( const auto &[kSinkPart, value1]: cI1S1Iz1Sz1_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
             for ( const auto &[kSrcHole, value3]: value2 ) {
                 for ( const auto &[kSrcPart, value4]: value3 ) {
                     // write the result
-                    momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S1Iz1Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S1Iz1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                    momNode = fmt::format("/cI1S1Iz1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S1Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                    momNode = fmt::format("/cI1S1Iz1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S1Iz1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                    momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
 
                     momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
                     this->h5_.write(cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S1Izn1Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S1Izn1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                    momNode = fmt::format("/cI1S1Izn1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S1Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                    momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
 
                     momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
                     this->h5_.write(cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
@@ -333,19 +369,35 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
         // compute the correlator. The result is stored in corrPool_
         measure(this->params_["Number Time Sources"]);
         std::string momNode;
-        for ( const auto &[kSinkPart, value1]: cI1S1Izn1Szn1_ ) {
+        for ( const auto &[kSinkPart, value1]: cI1S1Iz1Sz1_ ) {
             for ( const auto &[kSinkHole, value2]: value1 ) {
                 for ( const auto &[kSrcHole, value3]: value2 ) {
                     for ( const auto &[kSrcPart, value4]: value3 ) {
                         // write the result
-                        momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S1Iz1Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S1Iz1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                        momNode = fmt::format("/cI1S1Iz1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S1Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                        momNode = fmt::format("/cI1S1Iz1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S1Iz1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                        momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
 
                         momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
                         this->h5_.write(cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
 
-                        momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S1Izn1Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S1Izn1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                        momNode = fmt::format("/cI1S1Izn1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S1Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                        momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
 
                         momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
                         this->h5_.write(cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
@@ -363,7 +415,104 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz1_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+
+    std::vector<NSL::size_t> tDim{0};
+    
+    // NSL::Tensor<Type> eye(params_["device"].to<NSL::Device>(),kDim,kDim,Nt,bDim,bDim);
+    // for (int k=0; k<kDim; k++) {
+    //     for (int nt=0;nt<Nt; nt++){
+    //         eye(k,k,nt,NSL::Slice(), NSL::Slice()) = NSL::Matrix::Identity<Type> (bDim);
+    //     }
+    // }
+
+    for ( const auto &[kSinkPart, value1]: cI1S1Iz1Sz1_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+
+                                    cI1S1Iz1Sz1_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
+                                    
+                                    += ((NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)
+                                    
+                                    - NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim))
+
+                                    // + eye(kSinkHole, kSrcHole, NSL::Slice(), bSinkHole, bSrcHole) * corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart)
+
+                                    / Type(params_["Number Time Sources"]));
+                                }
+                            }
+                        }
+                    } 
+                }
+            }
+        }
+    }
+}
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz0_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+
+    std::vector<NSL::size_t> tDim{0};
+
+    for ( const auto &[kSinkPart, value1]: cI1S1Iz1Sz0_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+
+                                    cI1S1Iz1Sz0_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
+                                    
+                                    += -1*(0.5 * ((NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim) 
+                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)
+                                    
+                                    - NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim) 
+                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart)
+                                    
+                                    - corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim)
+                                    
+                                    + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)) 
+                                    
+                                    / Type(params_["Number Time Sources"])));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Szn1_() {
     int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
@@ -375,7 +524,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
     //     }
     // }
 
-    for ( const auto &[kSinkPart, value1]: cI1S1Izn1Szn1_ ) {
+    for ( const auto &[kSinkPart, value1]: cI1S1Iz1Szn1_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
             for ( const auto &[kSrcHole, value3]: value2 ) {
                 for ( const auto &[kSrcPart, value4]: value3 ) {
@@ -385,13 +534,13 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
                             for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
                                 for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
 
-                                    cI1S1Izn1Szn1_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
+                                    cI1S1Iz1Szn1_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
                                     
-                                    += ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)
+                                    += ((corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
+                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)
                                     
-                                    - corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart))
+                                    - corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
+                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart))
 
                                     // + eye(kSinkHole, kSrcHole, NSL::Slice(), bSinkHole, bSrcHole) * corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart)
 
@@ -400,6 +549,53 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
                             }
                         }
                     } 
+                }
+            }
+        }
+    }
+}
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Sz1_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+
+    std::vector<NSL::size_t> tDim{0};
+
+    for ( const auto &[kSinkPart, value1]: cI1S1Iz0Sz1_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+
+                                    cI1S1Iz0Sz1_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
+                                    
+                                    += (0.5 * ((NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim)
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)
+                                    
+                                    - NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim)
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim)
+                                    
+                                    - NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim)
+                                    
+                                    + NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)) 
+                                    
+                                    / Type(params_["Number Time Sources"])));
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -456,14 +652,21 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Sz1_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz1_() {
     int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
     std::vector<NSL::size_t> tDim{0};
+    
+    // NSL::Tensor<Type> eye(params_["device"].to<NSL::Device>(),kDim,kDim,Nt,bDim,bDim);
+    // for (int k=0; k<kDim; k++) {
+    //     for (int nt=0;nt<Nt; nt++){
+    //         eye(k,k,nt,NSL::Slice(), NSL::Slice()) = NSL::Matrix::Identity<Type> (bDim);
+    //     }
+    // }
 
-    for ( const auto &[kSinkPart, value1]: cI1S1Iz0Sz1_ ) {
+    for ( const auto &[kSinkPart, value1]: cI1S1Izn1Sz1_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
             for ( const auto &[kSrcHole, value3]: value2 ) {
                 for ( const auto &[kSrcPart, value4]: value3 ) {
@@ -473,25 +676,116 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Sz1_() {
                             for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
                                 for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
 
-                                    cI1S1Iz0Sz1_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
+                                    cI1S1Izn1Sz1_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
                                     
-                                    += (0.5 * ((NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim)
+                                    += ((NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim) 
                                     * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)
                                     
-                                    - NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim)
+                                    - NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim))
+
+                                    // + eye(kSinkHole, kSrcHole, NSL::Slice(), bSinkHole, bSrcHole) * corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart)
+
+                                    / Type(params_["Number Time Sources"]));
+                                }
+                            }
+                        }
+                    } 
+                }
+            }
+        }
+    }
+}
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz0_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+
+    std::vector<NSL::size_t> tDim{0};
+
+    for ( const auto &[kSinkPart, value1]: cI1S1Izn1Sz0_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+
+                                    cI1S1Izn1Sz0_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
+                                    
+                                    += -1*(0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)
+                                    
+                                    - corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
                                     * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim)
                                     
                                     - NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim) 
-                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim)
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart)
                                     
                                     + NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim) 
-                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)) 
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)) 
                                     
                                     / Type(params_["Number Time Sources"])));
                                 }
                             }
                         }
                     }
+                }
+            }
+        }
+    }
+}
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+    
+    // NSL::Tensor<Type> eye(params_["device"].to<NSL::Device>(),kDim,kDim,Nt,bDim,bDim);
+    // for (int k=0; k<kDim; k++) {
+    //     for (int nt=0;nt<Nt; nt++){
+    //         eye(k,k,nt,NSL::Slice(), NSL::Slice()) = NSL::Matrix::Identity<Type> (bDim);
+    //     }
+    // }
+
+    for ( const auto &[kSinkPart, value1]: cI1S1Izn1Szn1_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+
+                                    cI1S1Izn1Szn1_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
+                                    
+                                    += ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)
+                                    
+                                    - corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole) 
+                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart))
+
+                                    // + eye(kSinkHole, kSrcHole, NSL::Slice(), bSinkHole, bSrcHole) * corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart)
+
+                                    / Type(params_["Number Time Sources"]));
+                                }
+                            }
+                        }
+                    } 
                 }
             }
         }

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -148,6 +148,8 @@ class TwoBodyCorrelator: public Measurement {
 
         std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Izn1Szn1_;
         std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz0Szn1_;
+        std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI1S1Iz0Sz1_;
+
         std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, std::unordered_map<NSL::size_t, NSL::Tensor<Type>>>>> cI0S1Iz0Szn1_;
 
         NSL::Tensor<Type> phi_;
@@ -156,6 +158,8 @@ class TwoBodyCorrelator: public Measurement {
 
         void I1S1Izn1Szn1_();
         void I1S1Iz0Szn1_();
+        void I1S1Iz0Sz1_();
+
         void I0S1Iz0Szn1_();
 };
 
@@ -185,6 +189,8 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
                     cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
                     // cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
                     cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+                    cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
+
                     cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim, bDim, bDim, bDim);
                 }
             }
@@ -247,6 +253,8 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
 
         I1S1Izn1Szn1_();
         I1S1Iz0Szn1_();
+        I1S1Iz0Sz1_();
+
         I0S1Iz0Szn1_();
     } // for tscr
 
@@ -285,6 +293,9 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
 
                     momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
                     this->h5_.write(cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                    momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                    this->h5_.write(cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
 
                     momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
                     this->h5_.write(cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
@@ -332,6 +343,9 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
 
                         momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
                         this->h5_.write(cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+
+                        momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
+                        this->h5_.write(cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
 
                         momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
                         this->h5_.write(cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
@@ -425,6 +439,53 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Szn1_() {
                                     
                                     + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart) 
                                     * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole)) 
+                                    
+                                    / Type(params_["Number Time Sources"])));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+template<
+    NSL::Concept::isNumber Type,
+    NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
+    NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
+>
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Sz1_() {
+    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
+    int Nt = params_["Nt"].to<NSL::size_t>();
+
+    std::vector<NSL::size_t> tDim{0};
+
+    for ( const auto &[kSinkPart, value1]: cI1S1Iz0Sz1_ ) {
+        for ( const auto &[kSinkHole, value2]: value1 ) {
+            for ( const auto &[kSrcHole, value3]: value2 ) {
+                for ( const auto &[kSrcPart, value4]: value3 ) {
+
+                    for (int bSinkPart=0; bSinkPart<bDim; bSinkPart++) {
+                        for (int bSinkHole=0; bSinkHole<bDim; bSinkHole++) {
+                            for (int bSrcHole=0; bSrcHole<bDim; bSrcHole++) {
+                                for (int bSrcPart=0; bSrcPart<bDim; bSrcPart++) {
+
+                                    cI1S1Iz0Sz1_[kSinkPart][kSrcPart][kSinkHole][kSrcHole](NSL::Slice(), bSinkPart, bSrcPart, bSinkHole, bSrcHole)
+                                    
+                                    += (0.5 * ((NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim)
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)
+                                    
+                                    - NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim)
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim)
+                                    
+                                    - NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),bSinkPart,bSrcHole), tDim) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),bSinkHole,bSrcPart), tDim)
+                                    
+                                    + NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),bSinkPart,bSrcPart), tDim) 
+                                    * NSL::LinAlg::flip(corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),bSinkHole,bSrcHole), tDim)) 
                                     
                                     / Type(params_["Number Time Sources"])));
                                 }

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -215,27 +215,27 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
     int bDim = params_["wallSources"].shape(1);
 
     NSL::Tensor<double> momenta = params_["momenta"];
-    for (int kSinkPart=0; kSinkPart<kDim; kSinkPart++) {
-        for (int kSinkHole=0; kSinkHole<kDim; kSinkHole++) {
-            for (int kSrcHole=0; kSrcHole<kDim; kSrcHole++) {
-                for (int kSrcPart=0; kSrcPart<kDim; kSrcPart++) {
-                    if (!(eq_modBZ_(momenta(kSinkPart,NSL::Slice()) + momenta(kSinkHole,NSL::Slice()), momenta(kSrcPart, NSL::Slice()) + momenta(kSrcHole,NSL::Slice())))) {
+    for (int w=0; w<kDim; w++) {
+        for (int x=0; x<kDim; x++) {
+            for (int y=0; y<kDim; y++) {
+                for (int z=0; z<kDim; z++) {
+                    if (!(eq_modBZ_(momenta(w,NSL::Slice()) + momenta(x,NSL::Slice()), momenta(z, NSL::Slice()) + momenta(y,NSL::Slice())))) {
                         continue;
                     }
-                    cI1S1Iz1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Izn1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz1Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz1Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz0Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz0Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Izn1Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Izn1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Izn1Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
 
-                    cI0S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI0S1Iz0Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI0S1Iz0Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
 
-                    cI1S0Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S0Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S0Iz1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S0Izn1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
                 }
             }
         }
@@ -347,46 +347,46 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
 
     measure(1);
     std::string momNode;
-    for ( const auto &[kSinkPart, value1]: cI1S1Iz1Sz1_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI1S1Iz1Sz1_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
                     // write the result
-                    momNode = fmt::format("/cI1S1Iz1Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S1Iz1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S1Iz1Sz1/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI1S1Iz1Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Iz1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S1Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S1Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI1S1Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Iz1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S1Iz1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S1Iz1Szn1/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI1S1Iz1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI1S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI1S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Izn1Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S1Izn1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S1Izn1Sz1/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI1S1Izn1Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Izn1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S1Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S1Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI1S1Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
-
-
-                    momNode = fmt::format("/cI0S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI0S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
-                    momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI1S1Izn1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
 
-                    momNode = fmt::format("/cI1S0Iz1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S0Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
-                    momNode = fmt::format("/cI1S0Izn1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                    this->h5_.write(cI1S0Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI0S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI0S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI0S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
+
+
+                    momNode = fmt::format("/cI1S0Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI1S0Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    momNode = fmt::format("/cI1S0Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    this->h5_.write(cI1S0Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
                 }
             }
         }
@@ -421,46 +421,46 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
         // compute the correlator. The result is stored in corrPool_
         measure(this->params_["Number Time Sources"]);
         std::string momNode;
-        for ( const auto &[kSinkPart, value1]: cI1S1Iz1Sz1_ ) {
-            for ( const auto &[kSinkHole, value2]: value1 ) {
-                for ( const auto &[kSrcHole, value3]: value2 ) {
-                    for ( const auto &[kSrcPart, value4]: value3 ) {
+        for ( const auto &[w, value1]: cI1S1Iz1Sz1_ ) {
+            for ( const auto &[x, value2]: value1 ) {
+                for ( const auto &[y, value3]: value2 ) {
+                    for ( const auto &[z, value4]: value3 ) {
                         // write the result
-                        momNode = fmt::format("/cI1S1Iz1Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S1Iz1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S1Iz1Sz1/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI1S1Iz1Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                        momNode = fmt::format("/cI1S1Iz1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S1Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S1Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI1S1Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                        momNode = fmt::format("/cI1S1Iz1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S1Iz1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S1Iz1Szn1/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI1S1Iz1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                        momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI1S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                        momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI1S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                        momNode = fmt::format("/cI1S1Izn1Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S1Izn1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S1Izn1Sz1/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI1S1Izn1Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                        momNode = fmt::format("/cI1S1Izn1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S1Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S1Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI1S1Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                        momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
-
-
-                        momNode = fmt::format("/cI0S1Iz0Sz1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI0S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
-                        momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI1S1Izn1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
 
-                        momNode = fmt::format("/cI1S0Iz1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S0Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
-                        momNode = fmt::format("/cI1S0Izn1Sz0/{}-{}-{}-{}",kSinkPart,kSinkHole,kSrcPart,kSrcHole);
-                        this->h5_.write(cI1S0Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI0S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI0S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI0S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
+
+
+                        momNode = fmt::format("/cI1S0Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI1S0Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
+                        momNode = fmt::format("/cI1S0Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
+                        this->h5_.write(cI1S0Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
                     }
                 }
             }
@@ -491,25 +491,25 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz1_() {
     //     }
     // }
 
-    for ( const auto &[kSinkPart, value1]: cI1S1Iz1Sz1_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI1S1Iz1Sz1_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Iz1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI1S1Iz1Sz1_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += ((corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPoolDag_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += ((corrPoolDag_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l) 
+                                    * corrPoolDag_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)
                                     
-                                    - corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k)
-                                    * corrPoolDag_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),j,l))
+                                    - corrPoolDag_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k)
+                                    * corrPoolDag_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l))
 
-                                    // + eye(kSinkHole, kSrcHole, NSL::Slice(), j, k) * corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l)
+                                    // + eye(x, y, NSL::Slice(), j, k) * corrPool_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l)
 
                                     / Type(params_["Number Time Sources"]));
                                 }
@@ -532,29 +532,29 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz0_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    for ( const auto &[kSinkPart, value1]: cI1S1Iz1Sz0_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI1S1Iz1Sz0_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI1S1Iz1Sz0_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (-0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](kSrcPart,kSinkPart,NSL::Slice(), i,l)
-                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += (-0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](z,w,NSL::Slice(), i,l)
+                                    * corrPool_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
-                                    - corrPoolDag_[NSL::Hubbard::Particle](kSrcPart,kSinkHole,NSL::Slice(),i,k)
-                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    - corrPoolDag_[NSL::Hubbard::Particle](z,x,NSL::Slice(),i,k)
+                                    * corrPool_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l)
                                     
-                                    - corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPoolDag_[NSL::Hubbard::Particle](kSrcHole,kSinkPart,NSL::Slice(),j,l)
+                                    - corrPool_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
+                                    * corrPoolDag_[NSL::Hubbard::Particle](y,w,NSL::Slice(),j,l)
                                     
-                                    + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPoolDag_[NSL::Hubbard::Particle](kSrcHole,kSinkHole,NSL::Slice(),j,k)) 
+                                    + corrPool_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
+                                    * corrPoolDag_[NSL::Hubbard::Particle](y,x,NSL::Slice(),j,k)) 
                                     
                                     / Type(params_["Number Time Sources"])));
                                 }
@@ -577,23 +577,23 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Szn1_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    for ( const auto &[kSinkPart, value1]: cI1S1Iz1Szn1_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI1S1Iz1Szn1_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Iz1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI1S1Iz1Szn1_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += ((corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += ((corrPool_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
+                                    * corrPool_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
-                                    - corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l))
+                                    - corrPool_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
+                                    * corrPool_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l))
 
                                     / Type(params_["Number Time Sources"]));
                                 }
@@ -616,29 +616,29 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Sz1_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    for ( const auto &[kSinkPart, value1]: cI1S1Iz0Sz1_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI1S1Iz0Sz1_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI1S1Iz0Sz1_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l)
-                                    * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += (0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l)
+                                    * corrPoolDag_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
-                                    - corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k)
-                                    * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    - corrPoolDag_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k)
+                                    * corrPoolDag_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l)
                                     
-                                    - corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k)
-                                    * corrPoolDag_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    - corrPoolDag_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k)
+                                    * corrPoolDag_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l)
                                     
-                                    + corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l)
-                                    * corrPoolDag_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)) 
+                                    + corrPoolDag_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l)
+                                    * corrPoolDag_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
                                     / Type(params_["Number Time Sources"])));
                                 }
@@ -661,29 +661,29 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Szn1_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    for ( const auto &[kSinkPart, value1]: cI1S1Iz0Szn1_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI1S1Iz0Szn1_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI1S1Iz0Szn1_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += (0.5 * ((corrPool_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l) 
+                                    * corrPool_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
-                                    - corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    - corrPool_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k) 
+                                    * corrPool_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l)
                                     
-                                    - corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    - corrPool_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
+                                    * corrPool_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l)
                                     
-                                    + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)) 
+                                    + corrPool_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
+                                    * corrPool_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
                                     / Type(params_["Number Time Sources"])));
                                 }
@@ -706,23 +706,23 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz1_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    for ( const auto &[kSinkPart, value1]: cI1S1Izn1Sz1_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI1S1Izn1Sz1_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Izn1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI1S1Izn1Sz1_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += ((corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += ((corrPoolDag_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
+                                    * corrPoolDag_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
-                                    - corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l))
+                                    - corrPoolDag_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
+                                    * corrPoolDag_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l))
 
                                     / Type(params_["Number Time Sources"]));
                                 }
@@ -745,29 +745,29 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz0_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    for ( const auto &[kSinkPart, value1]: cI1S1Izn1Sz0_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI1S1Izn1Sz0_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI1S1Izn1Sz0_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (-0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += (-0.5 * ((corrPool_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l) 
+                                    * corrPoolDag_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
-                                    - corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    - corrPool_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k) 
+                                    * corrPoolDag_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l)
                                     
-                                    - corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    - corrPoolDag_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
+                                    * corrPool_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l)
                                     
-                                    + corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)) 
+                                    + corrPoolDag_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
+                                    * corrPool_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
                                     / Type(params_["Number Time Sources"])));
                                 }
@@ -790,23 +790,23 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    for ( const auto &[kSinkPart, value1]: cI1S1Izn1Szn1_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI1S1Izn1Szn1_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI1S1Izn1Szn1_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += ((corrPool_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l) 
+                                    * corrPool_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)
                                     
-                                    - corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),j,l))
+                                    - corrPool_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k) 
+                                    * corrPool_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l))
 
                                     / Type(params_["Number Time Sources"]));
                                 }
@@ -829,29 +829,29 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Sz1_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    for ( const auto &[kSinkPart, value1]: cI0S1Iz0Sz1_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI0S1Iz0Sz1_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI0S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI0S1Iz0Sz1_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += (0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l) 
+                                    * corrPoolDag_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
-                                    + corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    + corrPoolDag_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k) 
+                                    * corrPoolDag_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l)
                                     
-                                    + corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPoolDag_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    + corrPoolDag_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
+                                    * corrPoolDag_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l)
                                     
-                                    + corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPoolDag_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)) 
+                                    + corrPoolDag_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
+                                    * corrPoolDag_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
                                     / Type(params_["Number Time Sources"])));
 
@@ -875,29 +875,29 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Szn1_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    for ( const auto &[kSinkPart, value1]: cI0S1Iz0Szn1_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI0S1Iz0Szn1_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI0S1Iz0Szn1_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += (0.5 * ((corrPool_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l) 
+                                    * corrPool_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
-                                    + corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    + corrPool_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k) 
+                                    * corrPool_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l)
                                     
-                                    + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    + corrPool_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
+                                    * corrPool_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l)
                                     
-                                    + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)) 
+                                    + corrPool_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
+                                    * corrPool_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
                                     / Type(params_["Number Time Sources"])));
 
@@ -921,29 +921,29 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Iz1Sz0_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    for ( const auto &[kSinkPart, value1]: cI1S0Iz1Sz0_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI1S0Iz1Sz0_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S0Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI1S0Iz1Sz0_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (-0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += (-0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l) 
+                                    * corrPool_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
-                                    + corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    + corrPoolDag_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k) 
+                                    * corrPool_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l)
                                     
-                                    + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPoolDag_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    + corrPool_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
+                                    * corrPoolDag_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l)
                                     
-                                    + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPoolDag_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)) 
+                                    + corrPool_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
+                                    * corrPoolDag_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
                                     / Type(params_["Number Time Sources"])));
                                 }
@@ -966,29 +966,29 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Izn1Sz0_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    for ( const auto &[kSinkPart, value1]: cI1S0Izn1Sz0_ ) {
-        for ( const auto &[kSinkHole, value2]: value1 ) {
-            for ( const auto &[kSrcHole, value3]: value2 ) {
-                for ( const auto &[kSrcPart, value4]: value3 ) {
+    for ( const auto &[w, value1]: cI1S0Izn1Sz0_ ) {
+        for ( const auto &[x, value2]: value1 ) {
+            for ( const auto &[y, value3]: value2 ) {
+                for ( const auto &[z, value4]: value3 ) {
 
                     for (int i=0; i<bDim; i++) {
                         for (int j=0; j<bDim; j++) {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S0Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
+                                    cI1S0Izn1Sz0_[w][x][z][y](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (-0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
+                                    += (-0.5 * ((corrPool_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l) 
+                                    * corrPoolDag_[NSL::Hubbard::Hole](x,y,NSL::Slice(),j,k)
                                     
-                                    + corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    + corrPool_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k) 
+                                    * corrPoolDag_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l)
                                     
-                                    + corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),j,l)
+                                    + corrPoolDag_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
+                                    * corrPool_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l)
                                     
-                                    + corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)) 
+                                    + corrPoolDag_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
+                                    * corrPool_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
                                     / Type(params_["Number Time Sources"])));
                                 }

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -23,45 +23,45 @@ class TwoBodyCorrelator: public Measurement {
             cg_(hfm_, NSL::FermionMatrix::MMdagger),
             cgDag_(hfm_, NSL::FermionMatrix::MdaggerM),
             corrK_(
-                params["device"].to<NSL::Device>(),
-                params["wallSources"].shape(1).to<NSL::size_t>(),
-                params["Nt"].to<NSL::size_t>(),
-                params["Nx"].to<NSL::size_t>()
+                params["device"].template to<NSL::Device>(),
+                params["wallSources"].shape(1).template to<NSL::size_t>(),
+                params["Nt"].template to<NSL::size_t>(),
+                params["Nx"].template to<NSL::size_t>()
                 ),
             corrKDag_(
-                params["device"].to<NSL::Device>(),
-                params["wallSources"].shape(1).to<NSL::size_t>(),
-                params["Nt"].to<NSL::size_t>(),
-                params["Nx"].to<NSL::size_t>()
+                params["device"].template to<NSL::Device>(),
+                params["wallSources"].shape(1).template to<NSL::size_t>(),
+                params["Nt"].template to<NSL::size_t>(),
+                params["Nx"].template to<NSL::size_t>()
                 ),
             corrKPool_(
-                params["device"].to<NSL::Device>(),
-                params["wallSources"].shape(0).to<NSL::size_t>(),
-                params["wallSources"].shape(0).to<NSL::size_t>(),
+                params["device"].template to<NSL::Device>(),
+                params["wallSources"].shape(0).template to<NSL::size_t>(),
+                params["wallSources"].shape(0).template to<NSL::size_t>(),
                 // NSL::size_t (species_.size()), // I want to have a size 2 in this place
-                params["Nt"].to<NSL::size_t>(),
-                params["wallSources"].shape(1).to<NSL::size_t>(),
-                params["wallSources"].shape(1).to<NSL::size_t>()
+                params["Nt"].template to<NSL::size_t>(),
+                params["wallSources"].shape(1).template to<NSL::size_t>(),
+                params["wallSources"].shape(1).template to<NSL::size_t>()
                 ),
             corrKPoolDag_(
-                params["device"].to<NSL::Device>(),
-                params["wallSources"].shape(0).to<NSL::size_t>(),
-                params["wallSources"].shape(0).to<NSL::size_t>(),
+                params["device"].template to<NSL::Device>(),
+                params["wallSources"].shape(0).template to<NSL::size_t>(),
+                params["wallSources"].shape(0).template to<NSL::size_t>(),
                 // NSL::size_t (species_.size()), // I want to have a size 2 in this place
-                params["Nt"].to<NSL::size_t>(),
-                params["wallSources"].shape(1).to<NSL::size_t>(),
-                params["wallSources"].shape(1).to<NSL::size_t>()
+                params["Nt"].template to<NSL::size_t>(),
+                params["wallSources"].shape(1).template to<NSL::size_t>(),
+                params["wallSources"].shape(1).template to<NSL::size_t>()
                 ),
 	        srcVecK_(
-                params["device"].to<NSL::Device>(),
-                params["wallSources"].shape(1).to<NSL::size_t>(),
-                params["Nt"].to<NSL::size_t>(),
-                params["Nx"].to<NSL::size_t>()
+                params["device"].template to<NSL::Device>(),
+                params["wallSources"].shape(1).template to<NSL::size_t>(),
+                params["Nt"].template to<NSL::size_t>(),
+                params["Nx"].template to<NSL::size_t>()
             ),
             phi_(
-                params["device"].to<NSL::Device>(),
-                params["Nt"].to<NSL::size_t>(),
-                params["Nx"].to<NSL::size_t>()
+                params["device"].template to<NSL::Device>(),
+                params["Nt"].template to<NSL::size_t>(),
+                params["Nx"].template to<NSL::size_t>()
             ),
             basenode_(basenode_)
         {}
@@ -138,7 +138,7 @@ class TwoBodyCorrelator: public Measurement {
         //     int colsB = B.shape(2);
 
         //     // Result Tensor has shape ( (rowsA*rowsB) x (colsA*colsB) )
-        //     NSL::Tensor<Type> result(params_["device"].to<NSL::Device>(), A.shape(0), rowsA * rowsB, colsA * colsB);
+        //     NSL::Tensor<Type> result(params_["device"].template to<NSL::Device>(), A.shape(0), rowsA * rowsB, colsA * colsB);
 
         //     for (int i = 0; i < rowsA; ++i) {
         //         for (int j = 0; j < colsA; ++j) {
@@ -222,28 +222,28 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
                     if (!(eq_modBZ_(momenta(w,NSL::Slice()) + momenta(x,NSL::Slice()), momenta(z, NSL::Slice()) + momenta(y,NSL::Slice())))) {
                         continue;
                     }
-                    cI1S1Iz1Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz1Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz0Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Iz0Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Izn1Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Izn1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S1Izn1Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz1Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz1Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz0Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Iz0Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Izn1Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Izn1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S1Izn1Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
 
-                    cI0S1Iz0Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI0S1Iz0Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI0S1Iz0Sz1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI0S1Iz0Szn1_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
 
-                    cI1S0Iz1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
-                    cI1S0Izn1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S0Iz1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
+                    cI1S0Izn1Sz0_[w][x][z][y] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), Nt, bDim * bDim, bDim * bDim);
                 }
             }
         }
     }
-    corrPool_[NSL::Hubbard::Particle] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
-    corrPool_[NSL::Hubbard::Hole] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
-    corrPoolDag_[NSL::Hubbard::Particle] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
-    corrPoolDag_[NSL::Hubbard::Hole] = NSL::Tensor<Type> (params_["device"].to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
+    corrPool_[NSL::Hubbard::Particle] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
+    corrPool_[NSL::Hubbard::Hole] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
+    corrPoolDag_[NSL::Hubbard::Particle] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
+    corrPoolDag_[NSL::Hubbard::Hole] = NSL::Tensor<Type> (params_["device"].template to<NSL::Device>(), kDim, kDim, Nt, bDim, bDim);
 
 
     for (NSL::size_t tsrc = 0; tsrc<Nt; tsrc+=tsrcStep) {
@@ -340,56 +340,59 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
     node = "/NonInteracting/correlators/twobody";
     // this is a shortcut, we don't need to calculate the non-interacting 
     // correlators if we won't update the file
+    if(!skip_(this->params_["overwrite"],node)) {
+        // measure the non-interacting theory
+    	// U = 0 <=> phi = 0
+    	phi_ = Type(0);
 
-    // measure the non-interacting theory
-    // U = 0 <=> phi = 0
-    phi_ = Type(0);
+    	measure(1);
+    	std::string momNode;
+    	for ( const auto &[w, value1]: cI1S1Iz1Sz1_ ) {
+            for ( const auto &[x, value2]: value1 ) {
+            	for ( const auto &[y, value3]: value2 ) {
+                    for ( const auto &[z, value4]: value3 ) {
+                    	// write the result
+                    	momNode = fmt::format("/cI1S1Iz1Sz1/{}-{}-{}-{}",w,x,z,y);
+                    	this->h5_.write(cI1S1Iz1Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-    measure(1);
-    std::string momNode;
-    for ( const auto &[w, value1]: cI1S1Iz1Sz1_ ) {
-        for ( const auto &[x, value2]: value1 ) {
-            for ( const auto &[y, value3]: value2 ) {
-                for ( const auto &[z, value4]: value3 ) {
-                    // write the result
-                    momNode = fmt::format("/cI1S1Iz1Sz1/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI1S1Iz1Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                   	 momNode = fmt::format("/cI1S1Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    	 this->h5_.write(cI1S1Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI1S1Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	 momNode = fmt::format("/cI1S1Iz1Szn1/{}-{}-{}-{}",w,x,z,y);
+                    	 this->h5_.write(cI1S1Iz1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Iz1Szn1/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI1S1Iz1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	 momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
+                    	 this->h5_.write(cI1S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI1S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	 momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
+                    	 this->h5_.write(cI1S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI1S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	 momNode = fmt::format("/cI1S1Izn1Sz1/{}-{}-{}-{}",w,x,z,y);
+                    	 this->h5_.write(cI1S1Izn1Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Izn1Sz1/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI1S1Izn1Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	 momNode = fmt::format("/cI1S1Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    	 this->h5_.write(cI1S1Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI1S1Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	 momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",w,x,z,y);
+                    	 this->h5_.write(cI1S1Izn1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI1S1Izn1Szn1/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI1S1Izn1Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	 momNode = fmt::format("/cI0S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
+                    	 this->h5_.write(cI0S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
+			 momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
+                    	 this->h5_.write(cI0S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-                    momNode = fmt::format("/cI0S1Iz0Sz1/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI0S1Iz0Sz1_[w][x][z][y],std::string(basenode_)+node+momNode);
-                    momNode = fmt::format("/cI0S1Iz0Szn1/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI0S1Iz0Szn1_[w][x][z][y],std::string(basenode_)+node+momNode);
+                    	 momNode = fmt::format("/cI1S0Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    	 this->h5_.write(cI1S0Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
 
-
-                    momNode = fmt::format("/cI1S0Iz1Sz0/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI1S0Iz1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
-                    momNode = fmt::format("/cI1S0Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
-                    this->h5_.write(cI1S0Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
-                }
-            }
-        }
+			 momNode = fmt::format("/cI1S0Izn1Sz0/{}-{}-{}-{}",w,x,z,y);
+                    	 this->h5_.write(cI1S0Izn1Sz0_[w][x][z][y],std::string(basenode_)+node+momNode);
+                	 }
+            	     }
+       		 }
+    	    }
+        } else {
+        NSL::Logger::info("Non-interacting correlators already exist");
     }
     // Interacting Correlators
     // Initialize memory for the configurations
@@ -480,11 +483,11 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz1_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
-    // NSL::Tensor<Type> eye(params_["device"].to<NSL::Device>(),kDim,kDim,Nt,bDim,bDim);
+    // NSL::Tensor<Type> eye(params_["device"].template to<NSL::Device>(),kDim,kDim,Nt,bDim,bDim);
     // for (int k=0; k<kDim; k++) {
     //     for (int nt=0;nt<Nt; nt++){
     //         eye(k,k,nt,NSL::Slice(), NSL::Slice()) = NSL::Matrix::Identity<Type> (bDim);
@@ -528,9 +531,9 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz0_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
     for ( const auto &[w, value1]: cI1S1Iz1Sz0_ ) {
         for ( const auto &[x, value2]: value1 ) {
@@ -573,9 +576,9 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Szn1_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
     for ( const auto &[w, value1]: cI1S1Iz1Szn1_ ) {
         for ( const auto &[x, value2]: value1 ) {
@@ -612,9 +615,9 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Sz1_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
     for ( const auto &[w, value1]: cI1S1Iz0Sz1_ ) {
         for ( const auto &[x, value2]: value1 ) {
@@ -657,9 +660,9 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Szn1_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
     for ( const auto &[w, value1]: cI1S1Iz0Szn1_ ) {
         for ( const auto &[x, value2]: value1 ) {
@@ -702,9 +705,9 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz1_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
     for ( const auto &[w, value1]: cI1S1Izn1Sz1_ ) {
         for ( const auto &[x, value2]: value1 ) {
@@ -741,9 +744,9 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz0_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
     for ( const auto &[w, value1]: cI1S1Izn1Sz0_ ) {
         for ( const auto &[x, value2]: value1 ) {
@@ -786,9 +789,9 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
     for ( const auto &[w, value1]: cI1S1Izn1Szn1_ ) {
         for ( const auto &[x, value2]: value1 ) {
@@ -825,9 +828,9 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Sz1_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
     for ( const auto &[w, value1]: cI0S1Iz0Sz1_ ) {
         for ( const auto &[x, value2]: value1 ) {
@@ -871,9 +874,9 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Szn1_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
     for ( const auto &[w, value1]: cI0S1Iz0Szn1_ ) {
         for ( const auto &[x, value2]: value1 ) {
@@ -917,9 +920,9 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Iz1Sz0_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
     for ( const auto &[w, value1]: cI1S0Iz1Sz0_ ) {
         for ( const auto &[x, value2]: value1 ) {
@@ -962,9 +965,9 @@ template<
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
 void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Izn1Sz0_() {
-    int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
-    int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
-    int Nt = params_["Nt"].to<NSL::size_t>();
+    int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
+    int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
+    int Nt = params_["Nt"].template to<NSL::size_t>();
 
     for ( const auto &[w, value1]: cI1S0Izn1Sz0_ ) {
         for ( const auto &[x, value2]: value1 ) {

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -183,20 +183,20 @@ class TwoBodyCorrelator: public Measurement {
 
         std::string basenode_;
 
-        void I1S1Iz1Sz1_();
-        void I1S1Iz1Sz0_();
-        void I1S1Iz1Szn1_();
-        void I1S1Iz0Sz1_();
-        void I1S1Iz0Szn1_();
-        void I1S1Izn1Sz1_();
-        void I1S1Izn1Sz0_();
-        void I1S1Izn1Szn1_();
+        void I1S1Iz1Sz1_(NSL::size_t NumberTimeSources);
+        void I1S1Iz1Sz0_(NSL::size_t NumberTimeSources);
+        void I1S1Iz1Szn1_(NSL::size_t NumberTimeSources);
+        void I1S1Iz0Sz1_(NSL::size_t NumberTimeSources);
+        void I1S1Iz0Szn1_(NSL::size_t NumberTimeSources);
+        void I1S1Izn1Sz1_(NSL::size_t NumberTimeSources);
+        void I1S1Izn1Sz0_(NSL::size_t NumberTimeSources);
+        void I1S1Izn1Szn1_(NSL::size_t NumberTimeSources);
 
-        void I0S1Iz0Sz1_();
-        void I0S1Iz0Szn1_();
+        void I0S1Iz0Sz1_(NSL::size_t NumberTimeSources);
+        void I0S1Iz0Szn1_(NSL::size_t NumberTimeSources);
 
-        void I1S0Iz1Sz0_();
-        void I1S0Izn1Sz0_();
+        void I1S0Iz1Sz0_(NSL::size_t NumberTimeSources);
+        void I1S0Izn1Sz0_(NSL::size_t NumberTimeSources);
 };
 
 
@@ -306,20 +306,20 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(NSL::size_t 
             corrPoolDag_[species] = corrKPoolDag_.conj();
         } // for species
 
-        I1S1Iz1Sz1_();
-        I1S1Iz1Sz0_();
-        I1S1Iz1Szn1_();
-        I1S1Iz0Sz1_();
-        I1S1Iz0Szn1_();
-        I1S1Izn1Sz1_();
-        I1S1Izn1Sz0_();
-        I1S1Izn1Szn1_();
+        I1S1Iz1Sz1_(NumberTimeSources);
+        I1S1Iz1Sz0_(NumberTimeSources);
+        I1S1Iz1Szn1_(NumberTimeSources);
+        I1S1Iz0Sz1_(NumberTimeSources);
+        I1S1Iz0Szn1_(NumberTimeSources);
+        I1S1Izn1Sz1_(NumberTimeSources);
+        I1S1Izn1Sz0_(NumberTimeSources);
+        I1S1Izn1Szn1_(NumberTimeSources);
 
-        I0S1Iz0Sz1_();
-        I0S1Iz0Szn1_();
+        I0S1Iz0Sz1_(NumberTimeSources);
+        I0S1Iz0Szn1_(NumberTimeSources);
 
-        I1S0Iz1Sz0_();
-        I1S0Izn1Sz0_();
+        I1S0Iz1Sz0_(NumberTimeSources);
+        I1S0Izn1Sz0_(NumberTimeSources);
     } // for tscr
 
 } // measure(Ntsrc);
@@ -482,7 +482,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz1_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz1_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -514,7 +514,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz1_() {
 
                                     // + eye(x, y, NSL::Slice(), j, k) * corrPool_[NSL::Hubbard::Particle](w,z,NSL::Slice(),i,l)
 
-                                    / Type(params_["Number Time Sources"]));
+                                    / Type(NumberTimeSources));
                                 }
                             }
                         }
@@ -530,7 +530,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz0_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz0_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -559,7 +559,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz0_() {
                                     + corrPool_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
                                     * corrPoolDag_[NSL::Hubbard::Particle](y,x,NSL::Slice(),j,k)) 
                                     
-                                    / Type(params_["Number Time Sources"])));
+                                    / Type(NumberTimeSources)));
                                 }
                             }
                         }
@@ -575,7 +575,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Szn1_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Szn1_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -598,7 +598,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Szn1_() {
                                     - corrPool_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
                                     * corrPool_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l))
 
-                                    / Type(params_["Number Time Sources"]));
+                                    / Type(NumberTimeSources));
                                 }
                             }
                         }
@@ -614,7 +614,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Sz1_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Sz1_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -643,7 +643,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Sz1_() {
                                     + corrPoolDag_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l)
                                     * corrPoolDag_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
-                                    / Type(params_["Number Time Sources"])));
+                                    / Type(NumberTimeSources)));
                                 }
                             }
                         }
@@ -659,7 +659,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Szn1_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Szn1_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -688,7 +688,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Szn1_() {
                                     + corrPool_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
                                     * corrPool_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
-                                    / Type(params_["Number Time Sources"])));
+                                    / Type(NumberTimeSources)));
                                 }
                             }
                         }
@@ -704,7 +704,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz1_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz1_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -727,7 +727,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz1_() {
                                     - corrPoolDag_[NSL::Hubbard::Hole](w,y,NSL::Slice(),i,k) 
                                     * corrPoolDag_[NSL::Hubbard::Hole](x,z,NSL::Slice(),j,l))
 
-                                    / Type(params_["Number Time Sources"]));
+                                    / Type(NumberTimeSources));
                                 }
                             }
                         }
@@ -743,7 +743,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz0_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz0_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -772,7 +772,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz0_() {
                                     + corrPoolDag_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
                                     * corrPool_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
-                                    / Type(params_["Number Time Sources"])));
+                                    / Type(NumberTimeSources)));
                                 }
                             }
                         }
@@ -788,7 +788,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -811,7 +811,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
                                     - corrPool_[NSL::Hubbard::Particle](w,y,NSL::Slice(),i,k) 
                                     * corrPool_[NSL::Hubbard::Particle](x,z,NSL::Slice(),j,l))
 
-                                    / Type(params_["Number Time Sources"]));
+                                    / Type(NumberTimeSources));
                                 }
                             }
                         }
@@ -827,7 +827,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Sz1_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Sz1_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -856,7 +856,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Sz1_() {
                                     + corrPoolDag_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
                                     * corrPoolDag_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
-                                    / Type(params_["Number Time Sources"])));
+                                    / Type(NumberTimeSources)));
 
                                 }
                             }
@@ -873,7 +873,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Szn1_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Szn1_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -902,7 +902,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Szn1_() {
                                     + corrPool_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
                                     * corrPool_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
-                                    / Type(params_["Number Time Sources"])));
+                                    / Type(NumberTimeSources)));
 
                                 }
                             }
@@ -919,7 +919,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Iz1Sz0_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Iz1Sz0_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -948,7 +948,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Iz1Sz0_() {
                                     + corrPool_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
                                     * corrPoolDag_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
-                                    / Type(params_["Number Time Sources"])));
+                                    / Type(NumberTimeSources)));
                                 }
                             }
                         }
@@ -964,7 +964,7 @@ template<
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
     NSL::Concept::isDerived<NSL::FermionMatrix::FermionMatrix<Type,LatticeType>> FermionMatrixType
 >
-void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Izn1Sz0_() {
+void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Izn1Sz0_(NSL::size_t NumberTimeSources) {
     int kDim = params_["wallSources"].shape(0).template to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).template to<NSL::size_t>();
     int Nt = params_["Nt"].template to<NSL::size_t>();
@@ -993,7 +993,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Izn1Sz0_() {
                                     + corrPoolDag_[NSL::Hubbard::Hole](w,z,NSL::Slice(),i,l) 
                                     * corrPool_[NSL::Hubbard::Particle](x,y,NSL::Slice(),j,k)) 
                                     
-                                    / Type(params_["Number Time Sources"])));
+                                    / Type(NumberTimeSources)));
                                 }
                             }
                         }

--- a/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoBodyCorrelationFunction.tpp
@@ -470,6 +470,10 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
 
 } // measure()
 
+// The labels of the next functions might look incorrect but they infact are the correct one. 
+// We need to read the last two labels in the opposite direction because they are part of the opperator (O_{kl})^\dagger where the dagger swaps their place.
+// For further information check Petar's Excitons Notes
+
 template<
     NSL::Concept::isNumber Type,
     NSL::Concept::isDerived<NSL::Lattice::SpatialLattice<Type>> LatticeType,
@@ -480,8 +484,6 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz1_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    std::vector<NSL::size_t> tDim{0};
-    
     // NSL::Tensor<Type> eye(params_["device"].to<NSL::Device>(),kDim,kDim,Nt,bDim,bDim);
     // for (int k=0; k<kDim; k++) {
     //     for (int nt=0;nt<Nt; nt++){
@@ -499,7 +501,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz1_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Iz1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI1S1Iz1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
                                     += ((corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
                                     * corrPoolDag_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)
@@ -530,8 +532,6 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz0_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    std::vector<NSL::size_t> tDim{0};
-
     for ( const auto &[kSinkPart, value1]: cI1S1Iz1Sz0_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
             for ( const auto &[kSrcHole, value3]: value2 ) {
@@ -542,9 +542,9 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Sz0_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI1S1Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](kSrcPart,kSinkPart,NSL::Slice(), i,l)
+                                    += (-0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](kSrcPart,kSinkPart,NSL::Slice(), i,l)
                                     * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
                                     
                                     - corrPoolDag_[NSL::Hubbard::Particle](kSrcPart,kSinkHole,NSL::Slice(),i,k)
@@ -576,13 +576,6 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Szn1_() {
     int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
-    
-    // NSL::Tensor<Type> eye(params_["device"].to<NSL::Device>(),kDim,kDim,Nt,bDim,bDim);
-    // for (int k=0; k<kDim; k++) {
-    //     for (int nt=0;nt<Nt; nt++){
-    //         eye(k,k,nt,NSL::Slice(), NSL::Slice()) = NSL::Matrix::Identity<Type> (bDim);
-    //     }
-    // }
 
     for ( const auto &[kSinkPart, value1]: cI1S1Iz1Szn1_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
@@ -594,15 +587,13 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz1Szn1_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Iz1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI1S1Iz1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
                                     += ((corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
                                     * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
                                     
                                     - corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
                                     * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l))
-
-                                    // + eye(kSinkHole, kSrcHole, NSL::Slice(), j, k) * corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l)
 
                                     / Type(params_["Number Time Sources"]));
                                 }
@@ -625,8 +616,6 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Sz1_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    std::vector<NSL::size_t> tDim{0};
-
     for ( const auto &[kSinkPart, value1]: cI1S1Iz0Sz1_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
             for ( const auto &[kSrcHole, value3]: value2 ) {
@@ -637,7 +626,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Sz1_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI1S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
                                     += (0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l)
                                     * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
@@ -682,7 +671,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Iz0Szn1_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI1S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
                                     += (0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
                                     * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
@@ -717,15 +706,6 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz1_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    std::vector<NSL::size_t> tDim{0};
-    
-    // NSL::Tensor<Type> eye(params_["device"].to<NSL::Device>(),kDim,kDim,Nt,bDim,bDim);
-    // for (int k=0; k<kDim; k++) {
-    //     for (int nt=0;nt<Nt; nt++){
-    //         eye(k,k,nt,NSL::Slice(), NSL::Slice()) = NSL::Matrix::Identity<Type> (bDim);
-    //     }
-    // }
-
     for ( const auto &[kSinkPart, value1]: cI1S1Izn1Sz1_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
             for ( const auto &[kSrcHole, value3]: value2 ) {
@@ -736,15 +716,13 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz1_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Izn1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI1S1Izn1Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
                                     += ((corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
                                     * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
                                     
                                     - corrPoolDag_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
                                     * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l))
-
-                                    // + eye(kSinkHole, kSrcHole, NSL::Slice(), j, k) * corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l)
 
                                     / Type(params_["Number Time Sources"]));
                                 }
@@ -767,8 +745,6 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz0_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    std::vector<NSL::size_t> tDim{0};
-
     for ( const auto &[kSinkPart, value1]: cI1S1Izn1Sz0_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
             for ( const auto &[kSrcHole, value3]: value2 ) {
@@ -779,9 +755,9 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Sz0_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI1S1Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
+                                    += (-0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
                                     * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
                                     
                                     - corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
@@ -813,13 +789,6 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
     int kDim = params_["wallSources"].shape(0).to<NSL::size_t>();
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
-    
-    // NSL::Tensor<Type> eye(params_["device"].to<NSL::Device>(),kDim,kDim,Nt,bDim,bDim);
-    // for (int k=0; k<kDim; k++) {
-    //     for (int nt=0;nt<Nt; nt++){
-    //         eye(k,k,nt,NSL::Slice(), NSL::Slice()) = NSL::Matrix::Identity<Type> (bDim);
-    //     }
-    // }
 
     for ( const auto &[kSinkPart, value1]: cI1S1Izn1Szn1_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
@@ -831,15 +800,13 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S1Izn1Szn1_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI1S1Izn1Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
                                     += ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
                                     * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)
                                     
                                     - corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
                                     * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),j,l))
-
-                                    // + eye(kSinkHole, kSrcHole, NSL::Slice(), j, k) * corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l)
 
                                     / Type(params_["Number Time Sources"]));
                                 }
@@ -862,8 +829,6 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Sz1_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    std::vector<NSL::size_t> tDim{0};
-
     for ( const auto &[kSinkPart, value1]: cI0S1Iz0Sz1_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
             for ( const auto &[kSrcHole, value3]: value2 ) {
@@ -874,7 +839,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Sz1_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI0S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI0S1Iz0Sz1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
                                     += (0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
                                     * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
@@ -920,23 +885,7 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I0S1Iz0Szn1_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    // cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
-                                    
-                                    // += (0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    // * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
-                                    
-                                    // + corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    // * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcPart,NSL::Slice(),j,l)
-                                    
-                                    // + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
-                                    // * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcPart,NSL::Slice(),j,l)
-                                    
-                                    // + corrPool_[NSL::Hubbard::Hole](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
-                                    // * corrPool_[NSL::Hubbard::Particle](kSinkHole,kSrcHole,NSL::Slice(),j,k)) 
-                                    
-                                    // / Type(params_["Number Time Sources"])));
-
-                                    cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI0S1Iz0Szn1_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
                                     += (0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
                                     * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
@@ -972,8 +921,6 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Iz1Sz0_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    std::vector<NSL::size_t> tDim{0};
-
     for ( const auto &[kSinkPart, value1]: cI1S0Iz1Sz0_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
             for ( const auto &[kSrcHole, value3]: value2 ) {
@@ -984,9 +931,9 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Iz1Sz0_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S0Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI1S0Iz1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
+                                    += (-0.5 * ((corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
                                     * corrPool_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
                                     
                                     + corrPoolDag_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 
@@ -1019,8 +966,6 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Izn1Sz0_() {
     int bDim = params_["wallSources"].shape(1).to<NSL::size_t>();
     int Nt = params_["Nt"].to<NSL::size_t>();
 
-    std::vector<NSL::size_t> tDim{0};
-
     for ( const auto &[kSinkPart, value1]: cI1S0Izn1Sz0_ ) {
         for ( const auto &[kSinkHole, value2]: value1 ) {
             for ( const auto &[kSrcHole, value3]: value2 ) {
@@ -1031,9 +976,9 @@ void TwoBodyCorrelator<Type,LatticeType,FermionMatrixType>::I1S0Izn1Sz0_() {
                             for (int k=0; k<bDim; k++) {
                                 for (int l=0; l<bDim; l++) {
 
-                                    cI1S0Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, k * bDim + l)
+                                    cI1S0Izn1Sz0_[kSinkPart][kSinkHole][kSrcHole][kSrcPart](NSL::Slice(), i * bDim + j, l * bDim + k)
                                     
-                                    += (0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
+                                    += (-0.5 * ((corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcPart,NSL::Slice(),i,l) 
                                     * corrPoolDag_[NSL::Hubbard::Hole](kSinkHole,kSrcHole,NSL::Slice(),j,k)
                                     
                                     + corrPool_[NSL::Hubbard::Particle](kSinkPart,kSrcHole,NSL::Slice(),i,k) 

--- a/src/NSL/Measurements/Hubbard/twoPointCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoPointCorrelationFunction.tpp
@@ -296,7 +296,7 @@ void TwoPointCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
 	    }
 
         if (trimFlag) {
-            this->h5_.trimData(node);
+            this->h5_.deleteData(node);
             trimFlag = false;
         }
 

--- a/src/NSL/Measurements/Hubbard/twoPointCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoPointCorrelationFunction.tpp
@@ -184,7 +184,7 @@ void TwoPointCorrelator<Type,LatticeType,FermionMatrixType>::measureK(NSL::size_
     
     for(NSL::size_t tsrc = 0; tsrc<Nt; tsrc+=tsrcStep){
     	// Define a wall source
-	srcVecK_(NSL::Slice(),tsrc,NSL::Slice()) = NSL::Tensor<NSL::complex<double>> (params_["wallSources"])(k,NSL::Slice(),NSL::Slice());
+	    srcVecK_(NSL::Slice(),tsrc,NSL::Slice()) = NSL::Tensor<NSL::complex<double>> (params_["wallSources"])(k,NSL::Slice(),NSL::Slice());
 
         // invert MM^dagger
         NSL::Tensor<Type> invMMdag = cg_(srcVecK_);
@@ -203,21 +203,22 @@ void TwoPointCorrelator<Type,LatticeType,FermionMatrixType>::measureK(NSL::size_
         corrK_ += invM; // I changed something here!!!!!
 
         srcVecK_ = Type(0);
-     } // tsrc
+    } // tsrc
 
-     corrK_ /= Type(NumberTimeSources);
-     int uDim = params_["wallSources"].shape(1);
+    corrK_ /= Type(NumberTimeSources);
+    int uDim = params_["wallSources"].shape(1);
 
-     for (int t = 0;t< Nt;t++){
-       for(int sigma1=0; sigma1<uDim; sigma1++){
-         for(int sigma2=0; sigma2<uDim; sigma2++){
-     	   corrKblock_(t,sigma1,sigma2) = NSL::LinAlg::inner_product( NSL::Tensor<NSL::complex<double>> (params_["wallSources"])(k,sigma1,NSL::Slice()),corrK_(sigma2,t,NSL::Slice()));
-	 }
-}
+    // for (int t = 0;t< Nt;t++){
+        for(int sigma1=0; sigma1<uDim; sigma1++){
+            NSL::Tensor<Type> wallSource = NSL::Tensor<Type> (params_["wallSources"])(k,sigma1,NSL::Slice()).expand(Nt, 0);
+            for(int sigma2=0; sigma2<uDim; sigma2++){
+     	        corrKblock_(NSL::Slice(),sigma1,sigma2) = NSL::LinAlg::inner_product(wallSource, corrK_(sigma2,NSL::Slice(),NSL::Slice()), 1);
+	        }
+        }
 //	 corrKblock_(t,0,1) = NSL::LinAlg::inner_product( NSL::Tensor<NSL::complex<double>> (params_["wallSources"])(k,0,NSL::Slice()),corrK_(1,t,NSL::Slice()));
 //	 corrKblock_(t,1,0) = NSL::LinAlg::inner_product( NSL::Tensor<NSL::complex<double>> (params_["wallSources"])(k,1,NSL::Slice()),corrK_(0,t,NSL::Slice()));
 //	 corrKblock_(t,1,1) = NSL::LinAlg::inner_product( NSL::Tensor<NSL::complex<double>> (params_["wallSources"])(k,1,NSL::Slice()),corrK_(1,t,NSL::Slice()));
-     }
+    // }
 
      /*
      for (int t=0;t<Nt;t++) {

--- a/src/NSL/Measurements/Hubbard/twoPointCorrelationFunction.tpp
+++ b/src/NSL/Measurements/Hubbard/twoPointCorrelationFunction.tpp
@@ -276,6 +276,7 @@ void TwoPointCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
         minCfg, maxCfg, saveFreq
     );
 
+    bool trimFlag = false;
     // Determine the number of time sources:
     for (NSL::size_t cfgID = minCfg; cfgID<=maxCfg; ++cfgID){
         // this is a shortcut, we don't need to invert if we don't overwrite
@@ -289,8 +290,14 @@ void TwoPointCorrelator<Type,LatticeType,FermionMatrixType>::measure(){
 
         if (skip_(this->params_["overwrite"],node)) {
             NSL::Logger::info("Config #{} already has correlators, skipping... ", cfgID);
-	        continue;
-	    } 
+	        trimFlag = true;
+            continue;
+	    }
+
+        if (trimFlag) {
+            this->h5_.trimData(node);
+            trimFlag = false;
+        }
 
         NSL::Logger::info("Calculating Correlator on {}/{}", cfgID, maxCfg);
 

--- a/src/NSL/Tensor/Impl/expand.tpp
+++ b/src/NSL/Tensor/Impl/expand.tpp
@@ -22,20 +22,21 @@ class TensorExpand:
         return NSL::Tensor<Type>(this);
     }
 
-    NSL::Tensor<Type> expand(const NSL::size_t & newSize, const NSL::size_t & newDim) {
-        std::vector<NSL::size_t> sizes = this->data_.sizes().vec();
-        sizes.push_back(newSize);
-
-        this->data_ = this->data_.unsqueeze(newDim).expand(
-            torch::IntArrayRef(sizes)
-        ).clone();
-
-        return NSL::Tensor<Type>(this);
-    }
-
     // NSL::Tensor<Type> expand(const NSL::size_t & newSize, const NSL::size_t & newDim) {
-    //     return this->expand(newSize).transpose(newDim, -1);
+    //     std::vector<NSL::size_t> sizes = this->data_.sizes().vec();
+    //     sizes.push_back(newSize);
+
+    //     this->data_ = this->data_.unsqueeze(newDim).expand(
+    //         torch::IntArrayRef(sizes)
+    //     ).clone();
+
+    //     return NSL::Tensor<Type>(this);
     // }
+
+    // Maybe there is a better way of doing this but this was quickly coded
+    NSL::Tensor<Type> expand(const NSL::size_t & newSize, const NSL::size_t & newDim) {
+        return this->expand(newSize).transpose(newDim, -1);
+    }
 
 };
 

--- a/src/NSL/Tensor/Impl/expand.tpp
+++ b/src/NSL/Tensor/Impl/expand.tpp
@@ -22,6 +22,21 @@ class TensorExpand:
         return NSL::Tensor<Type>(this);
     }
 
+    NSL::Tensor<Type> expand(const NSL::size_t & newSize, const NSL::size_t & newDim) {
+        std::vector<NSL::size_t> sizes = this->data_.sizes().vec();
+        sizes.push_back(newSize);
+
+        this->data_ = this->data_.unsqueeze(newDim).expand(
+            torch::IntArrayRef(sizes)
+        ).clone();
+
+        return NSL::Tensor<Type>(this);
+    }
+
+    // NSL::Tensor<Type> expand(const NSL::size_t & newSize, const NSL::size_t & newDim) {
+    //     return this->expand(newSize).transpose(newDim, -1);
+    // }
+
 };
 
 } // namespace NSL::TensorImpl

--- a/src/NSL/Tensor/Impl/sqrt.tpp
+++ b/src/NSL/Tensor/Impl/sqrt.tpp
@@ -1,0 +1,23 @@
+#ifndef NSL_TENSOR_IMPL_SQRT_TPP
+#define NSL_TENSOR_IMPL_SQRT_TPP
+
+#include "base.tpp"
+
+namespace NSL::TensorImpl{
+
+template <NSL::Concept::isNumber Type>
+class TensorSqrt:
+    virtual private NSL::TensorImpl::TensorBase<Type>
+{
+    public:
+    //! Elementwise exponential
+    NSL::Tensor<Type> sqrt() {
+        this->data_.sqrt_();
+        return NSL::Tensor<Type>(this);
+    }
+
+};
+
+} // namespace NSL::TensorImpl
+
+#endif //NSL_TENSOR_IMPL_SQRT_TPP

--- a/src/NSL/Tensor/tensor.hpp
+++ b/src/NSL/Tensor/tensor.hpp
@@ -38,6 +38,7 @@
 #include "Tensor/Impl/trigonometric.tpp"
 #include "Tensor/Impl/reductions.tpp"
 #include "Tensor/Impl/matmul.tpp"
+#include "Tensor/Impl/sqrt.tpp"
 
 #include <stdexcept>
 
@@ -71,7 +72,8 @@ class Tensor:
     public NSL::TensorImpl::TensorDevice<Type>,
     public NSL::TensorImpl::TensorFlatten<Type>,
     public NSL::TensorImpl::TensorResize<Type>,
-    public NSL::TensorImpl::TensorReshape<Type>
+    public NSL::TensorImpl::TensorReshape<Type>,
+    public NSL::TensorImpl::TensorSqrt<Type>
 {
     public:
 

--- a/src/NSL/parameter.tpp
+++ b/src/NSL/parameter.tpp
@@ -1551,6 +1551,7 @@ typedef GeneralType<
     float,double,
     NSL::complex<float>,NSL::complex<double>,
     std::string,
+    std::vector<std::vector<std::vector<std::vector<double>>>>,
 
     // NSL Types
     NSL::Device

--- a/src/NSL/parameter.tpp
+++ b/src/NSL/parameter.tpp
@@ -1578,6 +1578,8 @@ typedef GeneralType<
     NSL::Tensor<double>,
     NSL::Tensor<NSL::complex<double>>,
 
+    std::vector<std::vector<double>>,
+
     // NSL Types
     NSL::Device
 >  GenType;


### PR DESCRIPTION
This branch implements Two-Body Correlation Functions in NSL. It does not support GPU (It should in the future). It should now have a correctly working checkpointing.

This implementation has only the connected spin-isospin channels.