### PR TITLE
Fixed acceptance probability output of a rejected configuration

### DIFF
--- a/src/NSL/MarkovChain/HMC.tpp
+++ b/src/NSL/MarkovChain/HMC.tpp
@@ -233,7 +233,7 @@ class HMC{
             return NSL::MCMC::MarkovState<Type>(
                 state.configuration,
                 state.actionValue,
-                state.acceptanceProbability,
+                acceptanceProb,
                 state.markovTime+1,
                 false
             );


### PR DESCRIPTION
This fix is for issue #174. It is possible now possible to tune the systems using an autotuner.