### PR TITLE
Catch nsl

### DIFF
--- a/src/NSL/MarkovChain/HMC.tpp
+++ b/src/NSL/MarkovChain/HMC.tpp
@@ -195,7 +195,8 @@ class HMC{
         }
 
         // use integrator to generate proposal 
-        auto [proposal_config,proposal_momentum] = this->integrator_(state.configuration,momentum);
+	try{
+	auto [proposal_config,proposal_momentum] = this->integrator_(state.configuration,momentum);
 
         // compute the Action
         Type proposal_S = this->action_(proposal_config);
@@ -231,6 +232,31 @@ class HMC{
             };
         } else {
             return NSL::MCMC::MarkovState<Type>(
+                state.configuration,
+                state.actionValue,
+                acceptanceProb,
+                state.markovTime+1,
+                false
+            );
+        }
+	}
+
+        catch (const std::exception& e) {
+              NSL::Logger::info( "# Warning! Exception in catch 1");
+              NSL::RealTypeOf<Type> acceptanceProb = 0.;
+              return NSL::MCMC::MarkovState<Type>(
+                state.configuration,
+                state.actionValue,
+                acceptanceProb,
+                state.markovTime+1,
+                false
+            );
+        }
+
+        catch (...) {
+              NSL::Logger::info( "# Warning! Exception in catch 2");
+              NSL::RealTypeOf<Type> acceptanceProb = 0.;
+              return NSL::MCMC::MarkovState<Type>(
                 state.configuration,
                 state.actionValue,
                 acceptanceProb,

--- a/src/NSL/MarkovChain/RadialHMC.tpp
+++ b/src/NSL/MarkovChain/RadialHMC.tpp
@@ -252,8 +252,9 @@ class RadialHMC{
             momentum[key] = p; 
         }
 
-        // use integrator to generate proposal 
-         auto [proposal_config,proposal_momentum] = this->integrator_(state.configuration,momentum);
+        // use integrator to generate proposal
+	try {
+        auto [proposal_config,proposal_momentum] = this->integrator_(state.configuration,momentum);
 
         // compute the Action
         Type proposal_S = this->action_(proposal_config);
@@ -276,8 +277,8 @@ class RadialHMC{
         // for complex actions!
         NSL::RealTypeOf<Type> acceptanceProb = NSL::LinAlg::exp( NSL::real(starting_H - proposal_H) );
 
-        // accept reject
-	    if ( r_.rand()[0] <= acceptanceProb ){
+	// accept reject
+        if ( r_.rand()[0] <= acceptanceProb ){
             return NSL::MCMC::MarkovState<Type>{
                 proposal_config,
                 proposal_S,
@@ -295,6 +296,54 @@ class RadialHMC{
                 false
             );
         }
+	}
+
+	catch (const std::exception& e) {
+	      NSL::Logger::info( "# Warning! Exception in catch 1");	
+              NSL::RealTypeOf<Type> acceptanceProb = 0.;
+	      return NSL::MCMC::MarkovState<Type>(
+                state.configuration,
+                state.actionValue,
+                acceptanceProb,
+                state.markovTime+1,
+                false
+            );
+        }
+
+	catch (...) {
+	      NSL::Logger::info( "# Warning! Exception in catch 2");
+     	      NSL::RealTypeOf<Type> acceptanceProb = 0.;
+	      return NSL::MCMC::MarkovState<Type>(
+                state.configuration,
+                state.actionValue,
+                acceptanceProb,
+                state.markovTime+1,
+                false
+            );
+	}
+
+
+/*
+        // accept reject
+	if ( r_.rand()[0] <= acceptanceProb ){
+            return NSL::MCMC::MarkovState<Type>{
+                proposal_config,
+                proposal_S,
+                acceptanceProb,
+                state.markovTime+1,
+                true
+                // For this algorithm there are no weights to be added //
+            };
+        } else {
+            return NSL::MCMC::MarkovState<Type>(
+                state.configuration,
+                state.actionValue,
+                acceptanceProb,
+                state.markovTime+1,
+                false
+            );
+        }
+	*/
     }
 
     //! Implementation of the HMC radial update

--- a/src/NSL/MarkovChain/RadialHMC.tpp
+++ b/src/NSL/MarkovChain/RadialHMC.tpp
@@ -321,29 +321,6 @@ class RadialHMC{
                 false
             );
 	}
-
-
-/*
-        // accept reject
-	if ( r_.rand()[0] <= acceptanceProb ){
-            return NSL::MCMC::MarkovState<Type>{
-                proposal_config,
-                proposal_S,
-                acceptanceProb,
-                state.markovTime+1,
-                true
-                // For this algorithm there are no weights to be added //
-            };
-        } else {
-            return NSL::MCMC::MarkovState<Type>(
-                state.configuration,
-                state.actionValue,
-                acceptanceProb,
-                state.markovTime+1,
-                false
-            );
-        }
-	*/
     }
 
     //! Implementation of the HMC radial update


### PR DESCRIPTION
Added try/catch to deal with exceptional configurations that (predominantly) appear during HMC simulations in the spin basis